### PR TITLE
fix: isolate WebSocket sessions per browser tab

### DIFF
--- a/src/lib/server/ws/handler.ts
+++ b/src/lib/server/ws/handler.ts
@@ -269,11 +269,14 @@ export function setupWebSocket(
 
     const githubToken: string = session.githubToken;
     const userLogin: string = session.githubUser?.login || 'unknown';
-    console.log('[WS-SERVER] Authenticated user:', userLogin, 'checking pool...');
-    let entry = sessionPool.get(userLogin);
+    const reqUrl = new URL(req.url || '/', `http://${req.headers.host}`);
+    const tabId = reqUrl.searchParams.get('tabId') || 'default';
+    const poolKey = `${userLogin}:${tabId}`;
+    console.log('[WS-SERVER] Authenticated user:', userLogin, 'tab:', tabId, 'checking pool...');
+    let entry = sessionPool.get(poolKey);
 
     if (entry) {
-      console.log('[WS-SERVER] Existing pool entry found for', userLogin);
+      console.log('[WS-SERVER] Existing pool entry found for', poolKey);
       // Reattach to existing pool entry
       if (entry.ws && entry.ws !== ws && entry.ws.readyState === WebSocket.OPEN) {
         entry.ws.close(4002, 'Replaced by new connection');
@@ -292,7 +295,7 @@ export function setupWebSocket(
         }
       }
 
-      console.log('[WS-SERVER] Sending session_reconnected to', userLogin, 'hasSession:', !!entry.session);
+      console.log('[WS-SERVER] Sending session_reconnected to', poolKey, 'hasSession:', !!entry.session);
       poolSend(entry, {
         type: 'session_reconnected',
         user: userLogin,
@@ -301,12 +304,12 @@ export function setupWebSocket(
       });
     } else {
       // Create new pool entry
-      console.log('[WS-SERVER] Creating new pool entry for', userLogin);
+      console.log('[WS-SERVER] Creating new pool entry for', poolKey);
       const client = createCopilotClient(githubToken, config.copilotConfigDir);
       entry = createPoolEntry(client, ws);
-      sessionPool.set(userLogin, entry);
+      sessionPool.set(poolKey, entry);
 
-      console.log('[WS-SERVER] Sending connected to', userLogin);
+      console.log('[WS-SERVER] Sending connected to', poolKey);
       poolSend(entry, {
         type: 'connected',
         user: userLogin,
@@ -317,12 +320,12 @@ export function setupWebSocket(
     const connectionEntry = entry;
 
     ws.on('close', (code: number, reason: Buffer) => {
-      console.log('[WS-SERVER] Client disconnected:', userLogin, 'code:', code, 'reason:', reason?.toString());
+      console.log('[WS-SERVER] Client disconnected:', poolKey, 'code:', code, 'reason:', reason?.toString());
       if (connectionEntry.ws === ws) {
         connectionEntry.ws = null;
         connectionEntry.ttlTimer = setTimeout(async () => {
           await destroyPoolEntry(connectionEntry);
-          sessionPool.delete(userLogin);
+          sessionPool.delete(poolKey);
         }, config.sessionPoolTtl);
       }
     });

--- a/src/lib/stores/ws.svelte.ts
+++ b/src/lib/stores/ws.svelte.ts
@@ -12,6 +12,9 @@ const MAX_RECONNECT_DELAY = 60_000;
 const UNAUTHORIZED_CODE = 4001;
 const REPLACED_CODE = 4002;
 
+// Unique ID for this browser tab so the server can isolate sessions per tab
+const TAB_ID = crypto.randomUUID();
+
 export interface WsStore {
   readonly connectionState: ConnectionState;
   readonly sessionReady: boolean;
@@ -92,7 +95,7 @@ export function createWsStore(): WsStore {
   function buildWsUrl(): string {
     if (typeof window === 'undefined') return '';
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return `${proto}//${window.location.host}/ws`;
+    return `${proto}//${window.location.host}/ws?tabId=${TAB_ID}`;
   }
 
   function setupVisibilityHandler(): void {


### PR DESCRIPTION
## Problem

The WebSocket session pool is keyed by GitHub username only. When a user opens a second browser tab, the new tab's WebSocket **replaces** the first tab's connection (close code 4002), and both tabs share a single `PoolEntry` — including session state, message buffer, `userInputResolve`, and `permissionResolve` handlers. This causes:

- Tab A's response stops mid-stream when Tab B connects
- Messages from one tab leak into the other
- Permission/input prompts resolve across tabs unexpectedly

## Fix

- **Frontend**: Generate a unique `tabId` per browser tab via `crypto.randomUUID()` and pass it as a query parameter on the WebSocket URL
- **Backend**: Use `username:tabId` as the session pool key instead of just `username`

Each tab now gets its own independent `PoolEntry` with separate session, message buffer, and input handlers. Reconnection within the same tab (e.g., network blip) still works as before since the `tabId` persists for the tab's lifetime.

## Changes

- `src/lib/stores/ws.svelte.ts`: Generate `TAB_ID` constant, append to WebSocket URL
- `src/lib/server/ws/handler.ts`: Extract `tabId` from URL params, use `poolKey = username:tabId`