### PR TITLE
fix: show correct tool info in permission request dialog

### DIFF
--- a/src/lib/components/PermissionPrompt.svelte
+++ b/src/lib/components/PermissionPrompt.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   interface Props {
     requestId: string;
+    kind: string;
     toolName: string;
     toolArgs: Record<string, unknown>;
     onRespond: (requestId: string, decision: 'allow' | 'deny' | 'always_allow') => void;
   }
 
-  const { requestId, toolName, toolArgs, onRespond }: Props = $props();
+  const { requestId, kind, toolName, toolArgs, onRespond }: Props = $props();
 
   const COUNTDOWN_SECONDS = 30;
 
@@ -15,8 +16,20 @@
   let promptEl: HTMLDivElement | undefined = $state();
 
   const argsJson = $derived(JSON.stringify(toolArgs, null, 2));
+  const hasArgs = $derived(Object.keys(toolArgs).length > 0);
   const isLargeArgs = $derived(argsJson.length > 120);
   const isUrgent = $derived(secondsLeft <= 10);
+
+  const kindIcon: Record<string, string> = {
+    shell: '💻',
+    write: '✏️',
+    read: '📖',
+    mcp: '🔌',
+    url: '🌐',
+    'custom-tool': '🔧',
+    memory: '🧠',
+  };
+  const icon = $derived(kindIcon[kind] ?? '🔐');
 
   $effect(() => {
     const interval = setInterval(() => {
@@ -39,19 +52,24 @@
 </script>
 
 <div class="permission-prompt" class:urgent={isUrgent} bind:this={promptEl}>
-  <div class="permission-tool-name">🔐 {toolName}</div>
+  <div class="permission-header">
+    <span class="permission-kind-badge">{icon} {kind}</span>
+    <span class="permission-tool-name">{toolName}</span>
+  </div>
 
-  {#if isLargeArgs}
-    <button
-      class="permission-toggle"
-      onclick={() => argsExpanded = !argsExpanded}
-    >
-      {argsExpanded ? '▾ Hide arguments' : '▸ Show arguments'}
-    </button>
-  {/if}
+  {#if hasArgs}
+    {#if isLargeArgs}
+      <button
+        class="permission-toggle"
+        onclick={() => argsExpanded = !argsExpanded}
+      >
+        {argsExpanded ? '▾ Hide details' : '▸ Show details'}
+      </button>
+    {/if}
 
-  {#if !isLargeArgs || argsExpanded}
-    <pre class="permission-args">{argsJson}</pre>
+    {#if !isLargeArgs || argsExpanded}
+      <pre class="permission-args">{argsJson}</pre>
+    {/if}
   {/if}
 
   <div class="permission-actions">
@@ -102,10 +120,30 @@
     50% { box-shadow: 0 0 20px rgba(248, 81, 73, 0.35); }
   }
 
-  .permission-tool-name {
+  .permission-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--sp-2);
+    margin-bottom: var(--sp-1);
+    flex-wrap: wrap;
+  }
+
+  .permission-kind-badge {
+    background: rgba(210, 153, 34, 0.15);
     color: var(--yellow);
     font-weight: 600;
-    font-size: 0.9em;
+    font-size: 0.8em;
+    font-family: var(--font-mono);
+    padding: 1px 7px;
+    border-radius: 100px;
+    white-space: nowrap;
+  }
+
+  .permission-tool-name {
+    color: var(--fg);
+    font-size: 0.88em;
+    font-family: var(--font-mono);
+    word-break: break-all;
   }
 
   .permission-toggle {

--- a/src/lib/server/ws/handler.ts
+++ b/src/lib/server/ws/handler.ts
@@ -179,13 +179,87 @@ function makeUserInputHandler(entry: PoolEntry) {
 
 const PERMISSION_TIMEOUT_MS = 30_000;
 
+function extractPermissionDisplay(request: any): {
+  kind: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+} {
+  const kind: string = request.kind ?? 'unknown';
+
+  switch (kind) {
+    case 'shell':
+      return {
+        kind,
+        toolName: request.fullCommandText ?? 'shell command',
+        toolArgs: {
+          ...(request.intention && { intention: request.intention }),
+          ...(request.possiblePaths?.length && { paths: request.possiblePaths }),
+          ...(request.possibleUrls?.length && { urls: request.possibleUrls.map((u: any) => u.url) }),
+          ...(request.warning && { warning: request.warning }),
+        },
+      };
+    case 'write':
+      return {
+        kind,
+        toolName: request.fileName ?? 'file',
+        toolArgs: {
+          ...(request.intention && { intention: request.intention }),
+          ...(request.diff && { diff: request.diff }),
+        },
+      };
+    case 'read':
+      return {
+        kind,
+        toolName: request.path ?? 'file',
+        toolArgs: {
+          ...(request.intention && { intention: request.intention }),
+        },
+      };
+    case 'mcp':
+      return {
+        kind,
+        toolName: request.toolName ?? request.toolTitle ?? request.serverName ?? 'mcp tool',
+        toolArgs: request.args ?? {},
+      };
+    case 'url':
+      return {
+        kind,
+        toolName: request.url ?? 'url',
+        toolArgs: {
+          ...(request.intention && { intention: request.intention }),
+        },
+      };
+    case 'custom-tool':
+      return {
+        kind,
+        toolName: request.toolName ?? 'custom tool',
+        toolArgs: request.args ?? {},
+      };
+    case 'memory':
+      return {
+        kind,
+        toolName: request.subject ?? 'memory',
+        toolArgs: {
+          ...(request.fact && { fact: request.fact }),
+          ...(request.citations && { citations: request.citations }),
+        },
+      };
+    default:
+      return {
+        kind,
+        toolName: request.toolName ?? request.tool?.name ?? kind,
+        toolArgs: request.args ?? request.tool?.args ?? {},
+      };
+  }
+}
+
 function makePermissionHandler(entry: PoolEntry) {
   return (request: any) => {
-    const toolName = request.toolName ?? request.tool?.name ?? 'unknown';
-    const toolArgs = request.args ?? request.tool?.args ?? {};
+    const { kind, toolName, toolArgs } = extractPermissionDisplay(request);
 
-    // Check remembered preferences
-    const remembered = entry.permissionPreferences.get(toolName);
+    // Check remembered preferences keyed by kind (so "always allow shell" covers all shell cmds)
+    const prefKey = kind;
+    const remembered = entry.permissionPreferences.get(prefKey);
     if (remembered === 'allow') return Promise.resolve({ kind: 'approved' as const });
     if (remembered === 'deny') return Promise.resolve({ kind: 'denied-interactively-by-user' as const });
 
@@ -209,6 +283,7 @@ function makePermissionHandler(entry: PoolEntry) {
       poolSend(entry, {
         type: 'permission_request',
         requestId,
+        kind,
         toolName,
         toolArgs,
       });
@@ -619,11 +694,13 @@ export function setupWebSocket(
               poolSend(connectionEntry, { type: 'error', message: 'Invalid decision' });
               return;
             }
+            // Key preferences by kind so "always allow shell" covers all shell commands
+            const prefKey = msg.kind ?? msg.toolName;
             if (decision === 'always_allow') {
-              connectionEntry.permissionPreferences.set(msg.toolName, 'allow');
+              connectionEntry.permissionPreferences.set(prefKey, 'allow');
             }
             if (decision === 'always_deny') {
-              connectionEntry.permissionPreferences.set(msg.toolName, 'deny');
+              connectionEntry.permissionPreferences.set(prefKey, 'deny');
             }
             const permResolve = connectionEntry.permissionResolve;
             connectionEntry.permissionResolve = null;

--- a/src/lib/stores/chat.svelte.ts
+++ b/src/lib/stores/chat.svelte.ts
@@ -328,6 +328,7 @@ export function createChatStore(wsStore: WsStore): ChatStore {
       case 'permission_request':
         pendingPermission = {
           requestId: msg.requestId,
+          kind: msg.kind,
           toolName: msg.toolName,
           toolArgs: msg.toolArgs,
         };

--- a/src/lib/stores/ws.svelte.ts
+++ b/src/lib/stores/ws.svelte.ts
@@ -51,7 +51,7 @@ export interface WsStore {
   updatePlan(content: string): void;
   deletePlan(): void;
   respondToUserInput(answer: string, wasFreeform: boolean): void;
-  respondToPermission(requestId: string, toolName: string, decision: 'allow' | 'deny' | 'always_allow' | 'always_deny'): void;
+  respondToPermission(requestId: string, kind: string, toolName: string, decision: 'allow' | 'deny' | 'always_allow' | 'always_deny'): void;
 }
 
 export function createWsStore(): WsStore {
@@ -306,8 +306,8 @@ export function createWsStore(): WsStore {
     send({ type: 'user_input_response', answer, wasFreeform });
   }
 
-  function respondToPermission(requestId: string, toolName: string, decision: 'allow' | 'deny' | 'always_allow' | 'always_deny'): void {
-    send({ type: 'permission_response', requestId, toolName, decision });
+  function respondToPermission(requestId: string, kind: string, toolName: string, decision: 'allow' | 'deny' | 'always_allow' | 'always_deny'): void {
+    send({ type: 'permission_response', requestId, kind, toolName, decision });
   }
 
   // ── Return public interface ─────────────────────────────────────────────

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -259,6 +259,7 @@ export interface UserInputRequestMessage {
 export interface PermissionRequestMessage {
   type: 'permission_request';
   requestId: string;
+  kind: string;
   toolName: string;
   toolArgs: Record<string, unknown>;
 }
@@ -522,6 +523,7 @@ export interface UserInputResponseMessage {
 export interface PermissionResponseMessage {
   type: 'permission_response';
   requestId: string;
+  kind: string;
   toolName: string;
   decision: 'allow' | 'deny' | 'always_allow' | 'always_deny';
 }
@@ -671,6 +673,7 @@ export interface UserInputState {
 
 export interface PermissionRequestState {
   requestId: string;
+  kind: string;
   toolName: string;
   toolArgs: Record<string, unknown>;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -185,8 +185,9 @@
   }
 
   function handlePermissionResponse(requestId: string, decision: 'allow' | 'deny' | 'always_allow'): void {
+    const kind = chatStore.pendingPermission?.kind ?? '';
     const toolName = chatStore.pendingPermission?.toolName ?? '';
-    wsStore.respondToPermission(requestId, toolName, decision);
+    wsStore.respondToPermission(requestId, kind, toolName, decision);
     chatStore.clearPendingPermission();
   }
 </script>
@@ -232,6 +233,7 @@
       {#if chatStore.pendingPermission}
         <PermissionPrompt
           requestId={chatStore.pendingPermission.requestId}
+          kind={chatStore.pendingPermission.kind}
           toolName={chatStore.pendingPermission.toolName}
           toolArgs={chatStore.pendingPermission.toolArgs}
           onRespond={handlePermissionResponse}


### PR DESCRIPTION
## Problem

The permission request dialog was showing empty/blank information (fixes #41).

The `makePermissionHandler` was trying to read `request.toolName` and `request.args`, but the Copilot SDK sends **kind-discriminated** permission requests where most kinds carry their identity in different fields:

| Kind | Fields used |
|------|------------|
| `shell` | `fullCommandText` |
| `write` | `fileName`, `diff` |
| `read` | `path` |
| `url` | `url` |
| `mcp` | `toolName`, `serverName`, `args` |
| `custom-tool` | `toolName`, `args` |
| `memory` | `subject`, `fact` |

Since none of the common kinds have a top-level `toolName`, the handler fell through to `'unknown'` and sent empty args, producing a blank dialog.

## Changes

- **`handler.ts`**: Add `extractPermissionDisplay()` that maps each `kind` to the right display name and detail fields; key `permissionPreferences` by `kind` (so *Always Allow shell* covers all shell commands)
- **`types/index.ts`**: Add `kind` field to `PermissionRequestMessage`, `PermissionResponseMessage`, and `PermissionRequestState`
- **`PermissionPrompt.svelte`**: Show a `kind` badge with an icon (💻 shell, ✏️ write, 📖 read, 🔌 mcp, 🌐 url, 🔧 custom-tool, 🧠 memory) and the tool/file/command name below it; hide args section when empty
- **`chat.svelte.ts`**, **`ws.svelte.ts`**, **`+page.svelte`**: Thread `kind` through the state and response path

Closes #41