### PR TITLE
fix: replace sendAndWait with send, extend permission timeout, add browser notifications

### DIFF
--- a/src/lib/components/PermissionPrompt.svelte
+++ b/src/lib/components/PermissionPrompt.svelte
@@ -9,7 +9,7 @@
 
   const { requestId, kind, toolName, toolArgs, onRespond }: Props = $props();
 
-  const COUNTDOWN_SECONDS = 30;
+  const COUNTDOWN_SECONDS = 300; // 5 minutes
 
   let secondsLeft = $state(COUNTDOWN_SECONDS);
   let argsExpanded = $state(false);
@@ -18,7 +18,7 @@
   const argsJson = $derived(JSON.stringify(toolArgs, null, 2));
   const hasArgs = $derived(Object.keys(toolArgs).length > 0);
   const isLargeArgs = $derived(argsJson.length > 120);
-  const isUrgent = $derived(secondsLeft <= 10);
+  const isUrgent = $derived(secondsLeft <= 30);
 
   const kindIcon: Record<string, string> = {
     shell: '💻',
@@ -41,6 +41,33 @@
     }, 1000);
 
     return () => clearInterval(interval);
+  });
+
+  // Browser notification when the prompt appears (user may have switched tabs)
+  $effect(() => {
+    if (typeof Notification === 'undefined') return;
+
+    const fire = () => {
+      const notif = new Notification(`Tool approval needed: ${kind}`, {
+        body: toolName,
+        icon: '/favicon.png',
+        tag: requestId,
+        requireInteraction: true,
+      });
+      notif.onclick = () => {
+        window.focus();
+        notif.close();
+      };
+      return () => notif.close();
+    };
+
+    if (Notification.permission === 'granted') {
+      return fire();
+    } else if (Notification.permission === 'default') {
+      Notification.requestPermission().then((perm) => {
+        if (perm === 'granted') fire();
+      });
+    }
   });
 
   // Auto-scroll into view when the prompt appears
@@ -84,7 +111,7 @@
     </button>
   </div>
 
-  <div class="permission-countdown">Auto-deny in {secondsLeft}s</div>
+  <div class="permission-countdown">Auto-deny in {secondsLeft >= 60 ? `${Math.floor(secondsLeft / 60)}m ${secondsLeft % 60}s` : `${secondsLeft}s`}</div>
 </div>
 
 <style>

--- a/src/lib/server/ws/handler.ts
+++ b/src/lib/server/ws/handler.ts
@@ -66,6 +66,7 @@ function wireSessionEvents(session: any, entry: PoolEntry, sessionId?: string): 
   session.on('assistant.turn_end', () => {
     entry.isProcessing = false;
     poolSend(entry, { type: 'turn_end' });
+    poolSend(entry, { type: 'done' });
   });
   session.on('tool.execution_start', (event: any) => {
     console.log('[TOOL] execution_start:', event.data.toolName, 'mcp:', event.data.mcpServerName, '/', event.data.mcpToolName);
@@ -177,7 +178,7 @@ function makeUserInputHandler(entry: PoolEntry) {
   };
 }
 
-const PERMISSION_TIMEOUT_MS = 30_000;
+const PERMISSION_TIMEOUT_MS = 300_000; // 5 minutes
 
 function extractPermissionDisplay(request: any): {
   kind: string;
@@ -563,12 +564,10 @@ export function setupWebSocket(
               : undefined;
 
             connectionEntry.isProcessing = true;
-            await connectionEntry.session.sendAndWait({
+            await connectionEntry.session.send({
               prompt: content,
               ...(attachments?.length ? { attachments } : {}),
             });
-            connectionEntry.isProcessing = false;
-            poolSend(connectionEntry, { type: 'done' });
             break;
           }
 


### PR DESCRIPTION
## Summary

Fixes the false-positive timeout error and improves the tool approval UX.

### Changes

#### 🐛 Fix: eliminate false-positive 60s timeout error
Replaces `session.sendAndWait()` (which has a hardcoded 60s wait for `session.idle`) with `session.send()`. The `done` signal is now emitted from the `assistant.turn_end` event handler — the correct semantic completion point. Previously, users would see a complete response *and* a timeout error if `session.idle` arrived after 60s.

#### ⏱️ Fix: permission timeout extended to 5 minutes
`PERMISSION_TIMEOUT_MS`: 30s → 300s. `COUNTDOWN_SECONDS` in the UI component updated to match. Auto-deny no longer fires before the user has a chance to notice and respond.

#### 🔔 Feat: browser notifications for tool approval prompts
When a permission request arrives, a Web Notification is fired so users who have switched tabs are alerted. Lazily requests `Notification` permission on first trigger. Clicking the notification focuses the window. Graceful no-op if blocked.

#### 🎨 UX: countdown now shows m:ss format
Display changes from `"Auto-deny in 42s"` to `"Auto-deny in 4m 12s"` when ≥60s remain. `isUrgent` threshold updated to ≤30s.

---

Closes part of #44