### PR TITLE
feat: full SDK usage telemetry coverage

### DIFF
--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -23,7 +23,10 @@ import type { ChatMessage } from '$lib/types/index.js';
     if (message.inputTokens != null) parts.push(`in: ${message.inputTokens}`);
     if (message.outputTokens != null) parts.push(`out: ${message.outputTokens}`);
     if (message.reasoningTokens != null) parts.push(`reasoning: ${message.reasoningTokens}`);
+    if (message.cacheReadTokens) parts.push(`cache read: ${message.cacheReadTokens}`);
+    if (message.cacheWriteTokens) parts.push(`cache write: ${message.cacheWriteTokens}`);
     if (message.cost != null) parts.push(`cost: ${message.cost}×`);
+    if (message.duration != null) parts.push(`${message.duration}ms`);
     return parts.length > 0 ? `tokens — ${parts.join(' · ')}` : '';
   });
 

--- a/src/lib/components/EnvInfo.svelte
+++ b/src/lib/components/EnvInfo.svelte
@@ -21,7 +21,7 @@
       contextInfo.tokenLimit > 0
         ? Math.round((contextInfo.currentTokens / contextInfo.tokenLimit) * 100)
         : 0;
-    return `ctx: ${currentK}k/${limitK}k (${percentage}%)`;
+    return { text: `ctx: ${currentK}k/${limitK}k (${percentage}%)`, percentage };
   });
 
   const toolLine = $derived.by(() => {
@@ -51,7 +51,16 @@
     <div class="env-line session-title-line"><span class="dot blue"></span> {sessionTitle}</div>
   {/if}
   {#if contextDisplay}
-    <div class="env-line">{contextDisplay}</div>
+    <div class="env-line">{contextDisplay.text}</div>
+    <div class="context-bar-track">
+      <div
+        class="context-bar-fill"
+        class:green={contextDisplay.percentage < 50}
+        class:yellow={contextDisplay.percentage >= 50 && contextDisplay.percentage < 80}
+        class:red={contextDisplay.percentage >= 80}
+        style="width: {contextDisplay.percentage}%"
+      ></div>
+    </div>
   {/if}
 </div>
 
@@ -107,4 +116,23 @@
   .env-skeleton.short {
     width: 90px;
   }
+
+  .context-bar-track {
+    height: 4px;
+    background: var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-top: 2px;
+    max-width: 160px;
+  }
+
+  .context-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .context-bar-fill.green { background: var(--green); }
+  .context-bar-fill.yellow { background: var(--yellow); }
+  .context-bar-fill.red { background: var(--red); }
 </style>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { pickPrimaryQuota, type QuotaSnapshots } from '$lib/types/index.js';
+  import { pickPrimaryQuota, type QuotaSnapshots, type SessionUsageTotals } from '$lib/types/index.js';
 
   interface Props {
     open: boolean;
     currentAgent: string | null;
     quotaSnapshots: QuotaSnapshots | null;
+    sessionTotals: SessionUsageTotals;
     onClose: () => void;
     onNewChat: () => void;
     onOpenSessions: () => void;
@@ -16,6 +17,7 @@
     open,
     currentAgent,
     quotaSnapshots,
+    sessionTotals,
     onClose,
     onNewChat,
     onOpenSessions,
@@ -108,6 +110,28 @@
             {#if quotaInfo.resetLabel}
               <span class="quota-reset">{quotaInfo.resetLabel}</span>
             {/if}
+          </div>
+        {/if}
+
+        {#if sessionTotals.apiCalls > 0}
+          <div class="sidebar-section">
+            <span class="sidebar-label">Session Usage</span>
+            <div class="session-totals">
+              <span class="totals-line">in: {sessionTotals.inputTokens.toLocaleString()} · out: {sessionTotals.outputTokens.toLocaleString()}</span>
+              {#if sessionTotals.reasoningTokens > 0}
+                <span class="totals-line">reasoning: {sessionTotals.reasoningTokens.toLocaleString()}</span>
+              {/if}
+              {#if sessionTotals.cacheReadTokens > 0 || sessionTotals.cacheWriteTokens > 0}
+                <span class="totals-line">cache r: {sessionTotals.cacheReadTokens.toLocaleString()} · w: {sessionTotals.cacheWriteTokens.toLocaleString()}</span>
+              {/if}
+              <span class="totals-line">{sessionTotals.apiCalls} API calls · cost: {sessionTotals.totalCost}×</span>
+              {#if sessionTotals.totalDurationMs > 0}
+                <span class="totals-line">{(sessionTotals.totalDurationMs / 1000).toFixed(1)}s total API time</span>
+              {/if}
+              {#if sessionTotals.premiumRequests > 0}
+                <span class="totals-line">{sessionTotals.premiumRequests} premium requests</span>
+              {/if}
+            </div>
           </div>
         {/if}
 
@@ -283,6 +307,18 @@
   .quota-reset {
     font-family: var(--font-mono);
     font-size: 0.72em;
+    color: var(--fg-dim);
+  }
+
+  .session-totals {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .totals-line {
+    font-family: var(--font-mono);
+    font-size: 0.75em;
     color: var(--fg-dim);
   }
 </style>

--- a/src/lib/components/TopBar.svelte
+++ b/src/lib/components/TopBar.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import type { ConnectionState } from '$lib/types/index.js';
+  import type { ConnectionState, QuotaSnapshots } from '$lib/types/index.js';
+  import QuotaDot from '$lib/components/QuotaDot.svelte';
 
   interface Props {
     currentModel: string;
     connectionState: ConnectionState;
     sessionTitle: string | null;
+    quotaSnapshots: QuotaSnapshots | null;
     onToggleSidebar: () => void;
     onOpenModelSheet: () => void;
     onNewChat: () => void;
@@ -14,6 +16,7 @@
     currentModel,
     connectionState,
     sessionTitle,
+    quotaSnapshots,
     onToggleSidebar,
     onOpenModelSheet,
     onNewChat,
@@ -56,6 +59,7 @@
     {:else}
       <span class="model-name loading-text">{displayModel}</span>
     {/if}
+    <QuotaDot {quotaSnapshots} />
     <svg class="chevron" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
       <path d="M2.5 4 L5 6.5 L7.5 4"/>
     </svg>

--- a/src/lib/server/ws/handler.ts
+++ b/src/lib/server/ws/handler.ts
@@ -97,8 +97,12 @@ function wireSessionEvents(session: any, entry: PoolEntry, sessionId?: string): 
       outputTokens: event.data.outputTokens,
       totalTokens: event.data.totalTokens,
       reasoningTokens: event.data.reasoningTokens,
+      cacheReadTokens: event.data.cacheReadTokens,
+      cacheWriteTokens: event.data.cacheWriteTokens,
+      duration: event.data.duration,
       cost: event.data.cost,
       quotaSnapshots: normalizeQuotaSnapshots(event.data.quotaSnapshots),
+      copilotUsage: event.data.copilotUsage,
     });
   });
   session.on('session.warning', (event: any) => {
@@ -141,7 +145,21 @@ function wireSessionEvents(session: any, entry: PoolEntry, sessionId?: string): 
   });
   session.on('session.compaction_start', () => { poolSend(entry, { type: 'compaction_start' }); });
   session.on('session.compaction_complete', (event: any) => {
-    poolSend(entry, { type: 'compaction_complete', tokensRemoved: event.data?.tokensRemoved, messagesRemoved: event.data?.messagesRemoved });
+    poolSend(entry, {
+      type: 'compaction_complete',
+      tokensRemoved: event.data?.tokensRemoved,
+      messagesRemoved: event.data?.messagesRemoved,
+      preCompactionTokens: event.data?.preCompactionTokens,
+      postCompactionTokens: event.data?.postCompactionTokens,
+    });
+  });
+  session.on('session.shutdown', (event: any) => {
+    poolSend(entry, {
+      type: 'session_shutdown',
+      totalPremiumRequests: event.data?.totalPremiumRequests,
+      totalApiDurationMs: event.data?.totalApiDurationMs,
+      sessionStartTime: event.data?.sessionStartTime,
+    });
   });
   session.on('skill.invoked', (event: any) => {
     poolSend(entry, { type: 'skill_invoked', skillName: event.data?.skillName });

--- a/src/lib/stores/chat.svelte.ts
+++ b/src/lib/stores/chat.svelte.ts
@@ -16,6 +16,7 @@ import type {
   PlanState,
   QuotaSnapshots,
   QuotaSnapshot,
+  SessionUsageTotals,
 } from '$lib/types/index.js';
 import type { WsStore } from '$lib/stores/ws.svelte.js';
 import { notify } from '$lib/utils/notifications.js';
@@ -49,6 +50,7 @@ export interface ChatStore {
   // Context & quota
   readonly contextInfo: ContextInfo | null;
   readonly quotaSnapshots: QuotaSnapshots | null;
+  readonly sessionTotals: SessionUsageTotals;
 
   // Plan
   readonly plan: PlanState;
@@ -100,6 +102,13 @@ export function createChatStore(wsStore: WsStore): ChatStore {
   // ── Context & quota ─────────────────────────────────────────────────────
   let contextInfo = $state<ContextInfo | null>(null);
   let quotaSnapshots = $state<QuotaSnapshots | null>(null);
+
+  const emptyTotals: SessionUsageTotals = {
+    inputTokens: 0, outputTokens: 0, reasoningTokens: 0,
+    cacheReadTokens: 0, cacheWriteTokens: 0,
+    totalCost: 0, totalDurationMs: 0, apiCalls: 0, premiumRequests: 0,
+  };
+  let sessionTotals = $state<SessionUsageTotals>({ ...emptyTotals });
 
   // ── Plan ────────────────────────────────────────────────────────────────
   let plan = $state<PlanState>({ exists: false, content: '' });
@@ -275,9 +284,25 @@ export function createChatStore(wsStore: WsStore): ChatStore {
           inputTokens: msg.inputTokens,
           outputTokens: msg.outputTokens,
           reasoningTokens: msg.reasoningTokens,
+          cacheReadTokens: msg.cacheReadTokens,
+          cacheWriteTokens: msg.cacheWriteTokens,
+          duration: msg.duration,
           cost: msg.cost,
           quotaSnapshots: msg.quotaSnapshots,
+          copilotUsage: msg.copilotUsage,
         });
+        // Accumulate session totals
+        sessionTotals = {
+          inputTokens: sessionTotals.inputTokens + (msg.inputTokens ?? 0),
+          outputTokens: sessionTotals.outputTokens + (msg.outputTokens ?? 0),
+          reasoningTokens: sessionTotals.reasoningTokens + (msg.reasoningTokens ?? 0),
+          cacheReadTokens: sessionTotals.cacheReadTokens + (msg.cacheReadTokens ?? 0),
+          cacheWriteTokens: sessionTotals.cacheWriteTokens + (msg.cacheWriteTokens ?? 0),
+          totalCost: sessionTotals.totalCost + (msg.cost ?? 0),
+          totalDurationMs: sessionTotals.totalDurationMs + (msg.duration ?? 0),
+          apiCalls: sessionTotals.apiCalls + 1,
+          premiumRequests: sessionTotals.premiumRequests,
+        };
         if (msg.quotaSnapshots) {
           quotaSnapshots = msg.quotaSnapshots;
         }
@@ -417,13 +442,20 @@ export function createChatStore(wsStore: WsStore): ChatStore {
         addInfoMessage('Compacting conversation…');
         break;
 
-      case 'compaction_complete':
-        addInfoMessage(
-          'Compaction complete' +
-          (msg.tokensRemoved ? `: removed ${msg.tokensRemoved} tokens` : '') +
-          (msg.messagesRemoved ? `, ${msg.messagesRemoved} messages` : ''),
-        );
+      case 'compaction_complete': {
+        let compactionMsg = 'Compaction complete';
+        if (msg.preCompactionTokens != null && msg.postCompactionTokens != null) {
+          compactionMsg += `: ${msg.preCompactionTokens.toLocaleString()} → ${msg.postCompactionTokens.toLocaleString()} tokens`;
+        }
+        if (msg.tokensRemoved) {
+          compactionMsg += (msg.preCompactionTokens != null ? ', ' : ': ') + `removed ${msg.tokensRemoved.toLocaleString()} tokens`;
+        }
+        if (msg.messagesRemoved) {
+          compactionMsg += `, ${msg.messagesRemoved} messages`;
+        }
+        addInfoMessage(compactionMsg);
         break;
+      }
 
       case 'compaction_result':
         addInfoMessage(
@@ -477,6 +509,20 @@ export function createChatStore(wsStore: WsStore): ChatStore {
         };
         break;
 
+      case 'session_shutdown':
+        if (msg.totalPremiumRequests != null) {
+          sessionTotals = { ...sessionTotals, premiumRequests: msg.totalPremiumRequests };
+        }
+        if (msg.totalApiDurationMs != null) {
+          sessionTotals = { ...sessionTotals, totalDurationMs: msg.totalApiDurationMs };
+        }
+        addInfoMessage(
+          'Session ended' +
+          (msg.totalPremiumRequests != null ? ` · ${msg.totalPremiumRequests} premium requests` : '') +
+          (msg.totalApiDurationMs != null ? ` · ${(msg.totalApiDurationMs / 1000).toFixed(1)}s total API time` : ''),
+        );
+        break;
+
       case 'reasoning_changed':
         reasoningEffort = msg.effort;
         addInfoMessage(`Reasoning effort set to ${msg.effort}`);
@@ -500,6 +546,7 @@ export function createChatStore(wsStore: WsStore): ChatStore {
     pendingPermission = null;
     contextInfo = null;
     sessionDetail = null;
+    sessionTotals = { ...emptyTotals };
   }
 
   function addUserMessage(content: string): void {
@@ -541,6 +588,7 @@ export function createChatStore(wsStore: WsStore): ChatStore {
 
     get contextInfo() { return contextInfo; },
     get quotaSnapshots() { return quotaSnapshots; },
+    get sessionTotals() { return sessionTotals; },
 
     get plan() { return plan; },
 

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -8,6 +8,7 @@ import type {
   ServerMessage,
   SessionDetail,
   SessionSummary,
+  SessionUsageTotals,
   ToolInfo,
 } from '$lib/types/index.js';
 
@@ -282,8 +283,12 @@ describe('createChatStore', () => {
         inputTokens: 100,
         outputTokens: 250,
         reasoningTokens: 40,
+        cacheReadTokens: 50,
+        cacheWriteTokens: 10,
+        duration: 1200,
         cost: 0.12,
         quotaSnapshots: initialQuota,
+        copilotUsage: [{ type: 'prompt', tokens: 100 }],
       },
       { type: 'quota' },
       { type: 'quota', quotaSnapshots: updatedQuota },
@@ -292,7 +297,7 @@ describe('createChatStore', () => {
       { type: 'plan_changed' },
       { type: 'plan_updated', content: '1. Investigate\n2. Ship\n3. Verify', path: '/tmp/plan.md' },
       { type: 'compaction_start' },
-      { type: 'compaction_complete', tokensRemoved: 120, messagesRemoved: 3 },
+      { type: 'compaction_complete', tokensRemoved: 120, messagesRemoved: 3, preCompactionTokens: 5000, postCompactionTokens: 4880 },
       { type: 'compaction_result', messagesRemoved: 1 },
       { type: 'reasoning_changed', effort: 'high' },
     );
@@ -302,8 +307,12 @@ describe('createChatStore', () => {
       inputTokens: 100,
       outputTokens: 250,
       reasoningTokens: 40,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 10,
+      duration: 1200,
       cost: 0.12,
       quotaSnapshots: initialQuota,
+      copilotUsage: [{ type: 'prompt', tokens: 100 }],
     });
     expect(store.quotaSnapshots).toEqual(updatedQuota);
     expect(store.contextInfo).toEqual({ tokenLimit: 64000, currentTokens: 4000, messagesLength: 12 });
@@ -317,7 +326,7 @@ describe('createChatStore', () => {
       expect.objectContaining({ role: 'info', content: 'Plan updated' }),
       expect.objectContaining({ role: 'info', content: 'Plan saved' }),
       expect.objectContaining({ role: 'info', content: 'Compacting conversation…' }),
-      expect.objectContaining({ role: 'info', content: 'Compaction complete: removed 120 tokens, 3 messages' }),
+      expect.objectContaining({ role: 'info', content: 'Compaction complete: 5,000 → 4,880 tokens, removed 120 tokens, 3 messages' }),
       expect.objectContaining({ role: 'info', content: 'Compaction result, 1 messages' }),
       expect.objectContaining({ role: 'info', content: 'Reasoning effort set to high' }),
       expect.objectContaining({ role: 'info', content: 'Plan deleted' }),
@@ -406,6 +415,77 @@ describe('createChatStore', () => {
       expect.objectContaining({ role: 'info', content: 'Info' }),
       expect.objectContaining({ role: 'info', content: 'Exiting plan mode…' }),
       expect.objectContaining({ role: 'info', content: 'Exited plan mode' }),
+    ]);
+  });
+
+  it('accumulates session usage totals across multiple usage messages', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    expect(store.sessionTotals).toEqual({
+      inputTokens: 0, outputTokens: 0, reasoningTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0,
+      totalCost: 0, totalDurationMs: 0, apiCalls: 0, premiumRequests: 0,
+    });
+
+    dispatch(store, {
+      type: 'usage',
+      inputTokens: 100,
+      outputTokens: 200,
+      reasoningTokens: 30,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 10,
+      duration: 500,
+      cost: 2,
+    });
+
+    expect(store.sessionTotals).toEqual({
+      inputTokens: 100, outputTokens: 200, reasoningTokens: 30,
+      cacheReadTokens: 50, cacheWriteTokens: 10,
+      totalCost: 2, totalDurationMs: 500, apiCalls: 1, premiumRequests: 0,
+    });
+
+    dispatch(store, {
+      type: 'usage',
+      inputTokens: 150,
+      outputTokens: 300,
+      cost: 3,
+      duration: 700,
+    });
+
+    expect(store.sessionTotals).toEqual({
+      inputTokens: 250, outputTokens: 500, reasoningTokens: 30,
+      cacheReadTokens: 50, cacheWriteTokens: 10,
+      totalCost: 5, totalDurationMs: 1200, apiCalls: 2, premiumRequests: 0,
+    });
+
+    // clearMessages resets totals
+    store.clearMessages();
+    expect(store.sessionTotals.apiCalls).toBe(0);
+    expect(store.sessionTotals.inputTokens).toBe(0);
+  });
+
+  it('handles session_shutdown and updates premium requests', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    dispatch(store, {
+      type: 'usage',
+      inputTokens: 100,
+      outputTokens: 200,
+      cost: 1,
+    });
+
+    dispatch(store, {
+      type: 'session_shutdown',
+      totalPremiumRequests: 5,
+      totalApiDurationMs: 3200,
+      sessionStartTime: '2026-01-01T00:00:00Z',
+    });
+
+    expect(store.sessionTotals.premiumRequests).toBe(5);
+    expect(store.sessionTotals.totalDurationMs).toBe(3200);
+    expect(store.messages).toEqual([
+      expect.objectContaining({ role: 'usage' }),
+      expect.objectContaining({ role: 'info', content: 'Session ended · 5 premium requests · 3.2s total API time' }),
     ]);
   });
 });

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -225,14 +225,25 @@ export interface TitleChangedMessage {
   title: string;
 }
 
+export interface CopilotUsageItem {
+  type: string;
+  model?: string;
+  tokens?: number;
+  premiumRequests?: number;
+}
+
 export interface UsageMessage {
   type: 'usage';
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
   reasoningTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  duration?: number;
   cost?: number;
   quotaSnapshots?: QuotaSnapshots;
+  copilotUsage?: CopilotUsageItem[];
 }
 
 export interface WarningMessage {
@@ -336,6 +347,8 @@ export interface CompactionCompleteMessage {
   type: 'compaction_complete';
   tokensRemoved?: number;
   messagesRemoved?: number;
+  preCompactionTokens?: number;
+  postCompactionTokens?: number;
 }
 
 export interface CompactionResultMessage {
@@ -412,6 +425,25 @@ export interface ReasoningChangedMessage {
   effort: ReasoningEffort;
 }
 
+export interface SessionShutdownMessage {
+  type: 'session_shutdown';
+  totalPremiumRequests?: number;
+  totalApiDurationMs?: number;
+  sessionStartTime?: string;
+}
+
+export interface SessionUsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalCost: number;
+  totalDurationMs: number;
+  apiCalls: number;
+  premiumRequests: number;
+}
+
 export type ServerMessage =
   | ConnectedMessage
   | SessionCreatedMessage
@@ -463,7 +495,8 @@ export type ServerMessage =
   | ExitPlanModeRequestedMessage
   | ExitPlanModeCompletedMessage
   | ContextInfoMessage
-  | ReasoningChangedMessage;
+  | ReasoningChangedMessage
+  | SessionShutdownMessage;
 
 // ─── File attachment ─────────────────────────────────────────────────────────
 
@@ -644,8 +677,12 @@ export interface ChatMessage {
   inputTokens?: number;
   outputTokens?: number;
   reasoningTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  duration?: number;
   cost?: number;
   quotaSnapshots?: QuotaSnapshots;
+  copilotUsage?: CopilotUsageItem[];
 }
 
 // ─── Tool call tracking ─────────────────────────────────────────────────────

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -216,6 +216,7 @@
       currentModel={chatStore.currentModel}
       connectionState={wsStore.connectionState}
       sessionTitle={chatStore.sessionTitle}
+      quotaSnapshots={chatStore.quotaSnapshots}
       onToggleSidebar={() => sidebarOpen = true}
       onOpenModelSheet={() => modelSheetOpen = true}
       onNewChat={handleNewChat}
@@ -272,6 +273,7 @@
       open={sidebarOpen}
       currentAgent={chatStore.currentAgent}
       quotaSnapshots={chatStore.quotaSnapshots}
+      sessionTotals={chatStore.sessionTotals}
       onClose={() => sidebarOpen = false}
       onNewChat={handleNewChat}
       onOpenSessions={handleOpenSessions}


### PR DESCRIPTION
Closes #56

## Summary
Full coverage of SDK usage, quota & context window telemetry.

### Data capture
- Forward `cacheReadTokens`, `cacheWriteTokens`, `duration`, `copilotUsage` from `assistant.usage`
- Handle `session.shutdown` event (`totalPremiumRequests`, `totalApiDurationMs`)
- Forward `preCompactionTokens`/`postCompactionTokens` from `session.compaction_complete`

### Types
- `CopilotUsageItem`, `SessionShutdownMessage`, `SessionUsageTotals` types added
- Extended `UsageMessage`, `ChatMessage`, `CompactionCompleteMessage` with new fields

### Store
- Cumulative session totals (`sessionTotals`) accumulated on each usage message
- `session_shutdown` handler updates premium requests and total API duration
- `clearMessages()` resets session totals

### UI
- **QuotaDot** mounted in TopBar next to model pill (was defined but unused)
- **Usage line** shows cache read/write tokens and API call duration
- **Context window progress bar** in EnvInfo (color-coded green/yellow/red)
- **Compaction messages** show pre→post token counts
- **Session usage summary** in Sidebar (total in/out/reasoning/cache/cost/duration/API calls)

### Tests
- Unit tests for session totals accumulation across multiple usage messages
- Unit test for session_shutdown event handling
- Updated compaction test for pre/post token display