### PR TITLE
fix: make all new SDK events visible in chat UI

### DIFF
--- a/src/lib/stores/chat.svelte.ts
+++ b/src/lib/stores/chat.svelte.ts
@@ -547,13 +547,25 @@ export function createChatStore(wsStore: WsStore): ChatStore {
         break;
 
       case 'tool_partial_result':
-        // Partial tool output — update the existing tool call if tracked
+        messages = messages.map(m =>
+          m.toolCallId === msg.toolCallId
+            ? {
+                ...m,
+                toolProgressMessages: [...(m.toolProgressMessages ?? []), msg.partialOutput],
+              }
+            : m,
+        );
         break;
 
       case 'context_changed':
+        addInfoMessage(
+          `Context: ${msg.repository ?? msg.cwd}` +
+          (msg.branch ? ` (${msg.branch})` : ''),
+        );
         break;
 
       case 'workspace_file_changed':
+        addInfoMessage(`Workspace file ${msg.operation}d: ${msg.path}`);
         break;
     }
   }

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -535,14 +535,26 @@ describe('createChatStore', () => {
 
     store.clearMessages();
 
-    // context_changed and workspace_file_changed are accepted without error
+    // context_changed and workspace_file_changed produce info messages
     dispatch(
       store,
       { type: 'context_changed', cwd: '/tmp', gitRoot: '/tmp', repository: 'o/r', branch: 'main' },
       { type: 'workspace_file_changed', path: 'plan.md', operation: 'update' },
+    );
+    expect(store.messages).toEqual([
+      expect.objectContaining({ role: 'info', content: 'Context: o/r (main)' }),
+      expect.objectContaining({ role: 'info', content: 'Workspace file updated: plan.md' }),
+    ]);
+
+    store.clearMessages();
+
+    // tool_partial_result appends to tool progress messages
+    dispatch(
+      store,
+      { type: 'tool_start', toolCallId: 'tc-1', toolName: 'bash', mcpServerName: undefined, mcpToolName: undefined },
       { type: 'tool_partial_result', toolCallId: 'tc-1', partialOutput: 'partial data' },
     );
-    // These events don't produce visible messages but should not throw
-    expect(store.messages).toEqual([]);
+    const toolMsg = store.messages.find(m => m.toolCallId === 'tc-1');
+    expect(toolMsg?.toolProgressMessages).toEqual(['partial data']);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #53 — ensures all 6 new SDK event handlers produce visible output in the chat UI.

### Changes

- **`tool_partial_result`**: Appends partial output to the tool call's progress messages array, making it visible in the expandable ToolCall component
- **`context_changed`**: Shows repo/branch info as a subtle info message (e.g. "Context: owner/repo (main)")
- **`workspace_file_changed`**: Shows file operations as info messages (e.g. "Workspace file updated: plan.md")

### Tests updated
- Verifies context_changed produces correct info message with repo + branch
- Verifies workspace_file_changed produces correct info message  
- Verifies tool_partial_result appends to tool's progress messages