### PR TITLE
feat: Fleet Mode, Steering & Queueing, Custom Agents (#62, #50, #54)

### DIFF
--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -51,7 +51,7 @@
   let attachMenuOpen = $state(false);
 
   const isDisabled = $derived(
-    !pendingUserInput && (connectionState !== 'connected' || isStreaming || !sessionReady || isUploading),
+    !pendingUserInput && (connectionState !== 'connected' || !sessionReady || isUploading),
   );
 
   const canSend = $derived(
@@ -60,14 +60,18 @@
       : !isDisabled && (inputValue.trim().length > 0 || selectedFiles.length > 0),
   );
 
-  const placeholder = $derived.by(() => {
+  const inputPlaceholder = $derived.by(() => {
     if (pendingUserInput) return 'Type your answer…';
     if (connectionState === 'connecting') return 'Connecting…';
     if (connectionState !== 'connected') return 'Not connected';
     if (!sessionReady) return 'Starting session…';
-    if (isStreaming) return 'Waiting for response…';
-    return 'Ask Copilot…';
+    if (isStreaming) return 'Steer or queue a follow-up…';
+    return 'Ask anything…';
   });
+
+  const showSteeringIndicator = $derived(
+    !pendingUserInput && isStreaming && inputValue.trim().length > 0,
+  );
 
   function autoResize() {
     const el = textareaEl;
@@ -290,13 +294,19 @@
     <textarea
       bind:this={textareaEl}
       bind:value={inputValue}
-      {placeholder}
+      placeholder={inputPlaceholder}
       disabled={!pendingUserInput && isDisabled}
       maxlength={MAX_LENGTH}
       rows={2}
       oninput={handleInput}
       onkeydown={handleKeydown}
     ></textarea>
+
+    {#if showSteeringIndicator}
+      <div class="steering-indicator" role="status" aria-live="polite">
+        Sending now will steer the current response.
+      </div>
+    {/if}
 
     <div class="toolbar">
       <div class="toolbar-left">
@@ -365,6 +375,14 @@
 
       <div class="toolbar-right">
         {#if isStreaming || isWaiting}
+          {#if isStreaming && !pendingUserInput && canSend}
+            <button class="circle-btn send-btn" onclick={send} aria-label="Steer response">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M8 12 L8 4"/>
+                <path d="M4 7 L8 3 L12 7"/>
+              </svg>
+            </button>
+          {/if}
           <button class="circle-btn stop-btn" onclick={onAbort} aria-label="Stop generating">
             <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
               <rect x="2" y="2" width="10" height="10" rx="2"/>
@@ -518,9 +536,18 @@
     min-width: 0;
   }
 
+  .steering-indicator {
+    padding: 0 var(--sp-4);
+    color: var(--fg-dim);
+    font-family: var(--font-mono);
+    font-size: 0.75em;
+    line-height: 1.4;
+  }
+
   .toolbar-right {
     display: flex;
     align-items: center;
+    gap: var(--sp-2);
     flex-shrink: 0;
   }
 

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import type { ChatMessage } from '$lib/types/index.js';
+  import type { ChatMessage } from '$lib/types/index.js';
   import { renderMarkdown, highlightCodeBlocks, addCopyButtons } from '$lib/utils/markdown.js';
+  import FleetProgress from './FleetProgress.svelte';
   import ToolCall from '$lib/components/ToolCall.svelte';
   import ReasoningBlock from '$lib/components/ReasoningBlock.svelte';
 
@@ -106,6 +107,15 @@ import type { ChatMessage } from '$lib/types/index.js';
   <div class="subagent-line">
     <span class="subagent-icon">{subagentIcon}</span>
     <span>agent/{message.content}</span>
+  </div>
+
+{:else if message.role === 'fleet'}
+  <div class="fleet-line">
+    <span class="fleet-line-icon">⚡</span>
+    <span>{message.content}</span>
+    {#if message.fleetAgents && message.fleetAgents.length > 0}
+      <FleetProgress agents={message.fleetAgents} active={!message.content.includes('complete')} />
+    {/if}
   </div>
 
 {:else if message.role === 'tool' && toolState}
@@ -392,6 +402,20 @@ import type { ChatMessage } from '$lib/types/index.js';
   .subagent-icon {
     flex-shrink: 0;
     color: var(--purple);
+    font-weight: 700;
+  }
+
+  .fleet-line {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    margin: var(--sp-1) 0;
+    color: var(--purple);
+    font-size: 0.85em;
+    animation: msg-in 0.3s;
+  }
+
+  .fleet-line-icon {
     font-weight: 700;
   }
 

--- a/src/lib/components/FleetProgress.svelte
+++ b/src/lib/components/FleetProgress.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  interface FleetAgent {
+    agentId: string;
+    agentType: string;
+    status: 'running' | 'completed' | 'failed';
+    error?: string;
+  }
+
+  interface Props {
+    agents: FleetAgent[];
+    active: boolean;
+  }
+
+  const { agents, active }: Props = $props();
+
+  const completed = $derived(agents.filter((agent) => agent.status === 'completed').length);
+  const failed = $derived(agents.filter((agent) => agent.status === 'failed').length);
+  const running = $derived(agents.filter((agent) => agent.status === 'running').length);
+</script>
+
+{#if agents.length > 0}
+  <div class="fleet-progress" class:fleet-done={!active}>
+    <div class="fleet-header">
+      <span class="fleet-icon">⚡</span>
+      <span class="fleet-title">Fleet Mode</span>
+      {#if active}
+        <span class="fleet-badge running">{running} running</span>
+      {/if}
+      {#if completed > 0}
+        <span class="fleet-badge completed">{completed} done</span>
+      {/if}
+      {#if failed > 0}
+        <span class="fleet-badge failed">{failed} failed</span>
+      {/if}
+    </div>
+    <div class="fleet-agents">
+      {#each agents as agent (agent.agentId)}
+        <div
+          class="fleet-agent"
+          class:agent-running={agent.status === 'running'}
+          class:agent-completed={agent.status === 'completed'}
+          class:agent-failed={agent.status === 'failed'}
+        >
+          <span class="agent-status-icon">
+            {#if agent.status === 'running'}◐
+            {:else if agent.status === 'completed'}✓
+            {:else}✗
+            {/if}
+          </span>
+          <span class="agent-name">{agent.agentType || agent.agentId}</span>
+          {#if agent.error}
+            <span class="agent-error">{agent.error}</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .fleet-progress {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    margin: var(--sp-2) 0;
+    background: var(--bg-raised);
+    animation: msg-in 0.3s;
+  }
+
+  .fleet-done {
+    opacity: 0.7;
+  }
+
+  .fleet-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    margin-bottom: var(--sp-2);
+    font-size: 0.85em;
+    flex-wrap: wrap;
+  }
+
+  .fleet-icon {
+    color: var(--purple);
+    font-weight: 700;
+  }
+
+  .fleet-title {
+    font-weight: 600;
+    color: var(--fg);
+  }
+
+  .fleet-badge {
+    font-size: 0.75em;
+    padding: 0.1em 0.5em;
+    border-radius: 999px;
+    font-weight: 500;
+  }
+
+  .fleet-badge.running {
+    background: var(--purple);
+    color: var(--bg);
+  }
+
+  .fleet-badge.completed {
+    background: var(--green);
+    color: var(--bg);
+  }
+
+  .fleet-badge.failed {
+    background: var(--red);
+    color: var(--bg);
+  }
+
+  .fleet-agents {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+  }
+
+  .fleet-agent {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    font-size: 0.82em;
+    padding: var(--sp-1) var(--sp-2);
+    border-radius: var(--radius-sm);
+    background: var(--bg-overlay);
+  }
+
+  .agent-status-icon {
+    font-weight: 700;
+    width: 1em;
+    text-align: center;
+    display: inline-flex;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .agent-running .agent-status-icon {
+    color: var(--purple);
+    animation: spin 1.5s linear infinite;
+  }
+
+  .agent-completed .agent-status-icon {
+    color: var(--green);
+  }
+
+  .agent-failed .agent-status-icon {
+    color: var(--red);
+  }
+
+  .agent-name {
+    color: var(--fg-muted);
+  }
+
+  .agent-error {
+    color: var(--red);
+    font-size: 0.9em;
+    margin-left: auto;
+  }
+
+  @keyframes msg-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -5,6 +5,7 @@
     QuotaSnapshots,
     QuotaSnapshot,
     CustomToolDefinition,
+    CustomAgentDefinition,
     McpServerDefinition,
     SkillDefinition,
   } from '$lib/types/index.js';
@@ -20,6 +21,7 @@
     customInstructions: string;
     excludedTools: string[];
     customTools: CustomToolDefinition[];
+    customAgents: CustomAgentDefinition[];
     mcpServers: McpServerDefinition[];
     availableSkills: SkillDefinition[];
     disabledSkills: string[];
@@ -27,6 +29,7 @@
     onSaveInstructions: (instructions: string) => void;
     onToggleTool: (toolName: string, enabled: boolean) => void;
     onSaveCustomTools: (tools: CustomToolDefinition[]) => void;
+    onSaveCustomAgents: (agents: CustomAgentDefinition[]) => void;
     onSaveMcpServers: (servers: McpServerDefinition[]) => void;
     onToggleSkill: (skillName: string, enabled: boolean) => void;
     onSelectAgent: (name: string) => void;
@@ -47,6 +50,7 @@
     customInstructions,
     excludedTools,
     customTools,
+    customAgents,
     mcpServers,
     availableSkills,
     disabledSkills,
@@ -54,6 +58,7 @@
     onSaveInstructions,
     onToggleTool,
     onSaveCustomTools,
+    onSaveCustomAgents,
     onSaveMcpServers,
     onToggleSkill,
     onSelectAgent,
@@ -65,13 +70,14 @@
     onFetchSkills,
   }: Props = $props();
 
-  type AccordionSection = 'instructions' | 'tools' | 'mcp' | 'custom-tools' | 'agents' | 'skills' | 'quota' | 'compact' | null;
+  type AccordionSection = 'instructions' | 'tools' | 'mcp' | 'custom-agents' | 'custom-tools' | 'agents' | 'skills' | 'quota' | 'compact' | null;
 
   let activeSection = $state<AccordionSection>(null);
   let instructionsDraft = $state('');
 
   // ── MCP server editor state ─────────────────────────────────────────
   const MAX_MCP_SERVERS = 10;
+  const MAX_CUSTOM_AGENTS = 10;
   let mcpShowAddForm = $state(false);
   let mcpExpandedIndex = $state<number | null>(null);
   let mcpDeleteConfirmIndex = $state<number | null>(null);
@@ -83,7 +89,16 @@
   let mcpDraftEnabled = $state(true);
   let mcpFormError = $state('');
 
+  let agentEditing = $state<number | null>(null);
+  let agentDraftName = $state('');
+  let agentDraftDisplayName = $state('');
+  let agentDraftDescription = $state('');
+  let agentDraftPrompt = $state('');
+  let agentDraftTools = $state('');
+  let agentFormError = $state('');
+
   const canAddMoreMcp = $derived(mcpServers.length < MAX_MCP_SERVERS);
+  const canAddMoreAgents = $derived(customAgents.length < MAX_CUSTOM_AGENTS);
 
   function mcpResetDraft(): void {
     mcpDraftName = '';
@@ -177,6 +192,79 @@
     const updated = [...mcpServers];
     updated[index] = { ...updated[index], enabled: !updated[index].enabled };
     onSaveMcpServers(updated);
+  }
+
+  function agentValidateDraft(): string | null {
+    if (!agentDraftName.trim()) return 'Name is required';
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(agentDraftName.trim())) return 'Name must be alphanumeric/underscore/dash, max 64 chars';
+    if (!agentDraftPrompt.trim()) return 'Prompt is required';
+    return null;
+  }
+
+  function agentCancelEdit(): void {
+    agentEditing = null;
+    agentDraftName = '';
+    agentDraftDisplayName = '';
+    agentDraftDescription = '';
+    agentDraftPrompt = '';
+    agentDraftTools = '';
+    agentFormError = '';
+  }
+
+  function agentSave(): void {
+    const err = agentValidateDraft();
+    if (err) {
+      agentFormError = err;
+      return;
+    }
+
+    const duplicateIndex = customAgents.findIndex((agent, index) =>
+      agent.name === agentDraftName.trim() && index !== agentEditing
+    );
+    if (duplicateIndex >= 0) {
+      agentFormError = 'An agent with this name already exists';
+      return;
+    }
+
+    const agent: CustomAgentDefinition = {
+      name: agentDraftName.trim(),
+      displayName: agentDraftDisplayName.trim() || undefined,
+      description: agentDraftDescription.trim() || undefined,
+      tools: agentDraftTools.trim()
+        ? agentDraftTools.split(',').map((tool) => tool.trim()).filter(Boolean)
+        : undefined,
+      prompt: agentDraftPrompt.trim(),
+    };
+    const updatedAgents = [...customAgents];
+    if (agentEditing !== null) {
+      updatedAgents[agentEditing] = agent;
+    } else {
+      updatedAgents.push(agent);
+    }
+    onSaveCustomAgents(updatedAgents);
+    agentCancelEdit();
+  }
+
+  function agentStartEdit(index: number): void {
+    const agent = customAgents[index];
+    agentEditing = index;
+    agentDraftName = agent.name;
+    agentDraftDisplayName = agent.displayName ?? '';
+    agentDraftDescription = agent.description ?? '';
+    agentDraftPrompt = agent.prompt;
+    agentDraftTools = agent.tools?.join(', ') ?? '';
+    agentFormError = '';
+  }
+
+  function agentDelete(index: number): void {
+    onSaveCustomAgents(customAgents.filter((_, i) => i !== index));
+    if (agentEditing === index) {
+      agentCancelEdit();
+      return;
+    }
+    if (agentEditing !== null && agentEditing > index) {
+      agentEditing -= 1;
+    }
   }
 
   // Sync draft when prop changes (including initial value)
@@ -458,6 +546,77 @@
                 </div>
               {:else if canAddMoreMcp}
                 <button class="mcp-link-btn" style="margin-top: var(--sp-2)" onclick={() => { mcpResetDraft(); mcpShowAddForm = true; mcpExpandedIndex = null; }}>+ Add MCP server</button>
+              {/if}
+            </div>
+          {/if}
+        </div>
+
+        <!-- Custom Agents -->
+        <div class="settings-accordion">
+          <button
+            class="settings-accordion-btn"
+            class:open={activeSection === 'custom-agents'}
+            onclick={() => toggleSection('custom-agents')}
+          >
+            Custom Agents
+            <span class="accordion-chevron">▸</span>
+          </button>
+          {#if activeSection === 'custom-agents'}
+            <div class="settings-accordion-body">
+              <div style="display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); margin-bottom: var(--sp-2);">
+                <p class="settings-hint" style="margin-bottom: 0;">
+                  Define sub-agents with scoped tools and prompts for fleet mode delegation.
+                </p>
+                <span class="mcp-server-badge">{customAgents.length}/10</span>
+              </div>
+
+              {#each customAgents as agent, i (`${agent.name}-${i}`)}
+                <div class="mcp-server-item">
+                  <div class="mcp-server-header">
+                    <div style="flex: 1; min-width: 0;">
+                      <div class="mcp-server-name">{agent.displayName || agent.name}</div>
+                      <div class="tool-toggle-desc" style="padding-left: 0;">
+                        {agent.description || agent.name}
+                      </div>
+                    </div>
+                    <button class="mcp-edit-btn" onclick={() => agentStartEdit(i)} title="Edit">✎</button>
+                    <button class="mcp-edit-btn" style="color: var(--red);" onclick={() => agentDelete(i)} title="Delete">✕</button>
+                  </div>
+                </div>
+              {/each}
+
+              {#if agentEditing !== null || canAddMoreAgents}
+                <div class="mcp-form">
+                  {#if agentFormError}
+                    <div class="mcp-form-error">{agentFormError}</div>
+                  {/if}
+
+                  <div class="mcp-headers-label">Name <span style="color: var(--red);">*</span></div>
+                  <input class="mcp-input" type="text" bind:value={agentDraftName} placeholder="researcher" maxlength="64" />
+
+                  <div class="mcp-headers-label">Display Name</div>
+                  <input class="mcp-input" type="text" bind:value={agentDraftDisplayName} placeholder="Research Agent" />
+
+                  <div class="mcp-headers-label">Description</div>
+                  <input class="mcp-input" type="text" bind:value={agentDraftDescription} placeholder="Explores codebases using read-only tools" />
+
+                  <div class="mcp-headers-label">Prompt <span style="color: var(--red);">*</span></div>
+                  <textarea class="settings-textarea" bind:value={agentDraftPrompt} placeholder="You are a research assistant..." rows="3" style="min-height: 84px; max-height: 220px;"></textarea>
+
+                  <div class="mcp-headers-label">Tools (comma-separated, empty = all)</div>
+                  <input class="mcp-input" type="text" bind:value={agentDraftTools} placeholder="grep, glob, view" />
+
+                  <div class="mcp-form-actions">
+                    <button class="action-btn save" onclick={agentSave}>
+                      {agentEditing !== null ? 'Update' : 'Add'} Agent
+                    </button>
+                    {#if agentEditing !== null}
+                      <button class="action-btn" onclick={agentCancelEdit}>Cancel</button>
+                    {/if}
+                  </div>
+                </div>
+              {:else}
+                <div class="mcp-form-error" style="margin-top: var(--sp-2);">Maximum of {MAX_CUSTOM_AGENTS} agents reached</div>
               {/if}
             </div>
           {/if}

--- a/src/lib/server/copilot/session.test.ts
+++ b/src/lib/server/copilot/session.test.ts
@@ -384,6 +384,21 @@ describe('createCopilotSession', () => {
     expect(config.skillDirectories).toBeUndefined();
     expect(config.disabledSkills).toBeUndefined();
   });
+
+  it('passes custom agents to SDK session config', async () => {
+    const client = createClientMock();
+    const customAgents = [
+      { name: 'editor', prompt: 'Edit code', tools: ['bash', 'edit'] },
+      { name: 'reviewer', prompt: 'Review code', displayName: 'Code Reviewer' },
+    ];
+
+    await createCopilotSession(client as unknown as Parameters<typeof createCopilotSession>[0], 'gh-token', {
+      customAgents,
+    });
+
+    const config = getSessionConfig(client);
+    expect(config.customAgents).toEqual(customAgents);
+  });
 });
 
 describe('getAvailableModels', () => {

--- a/src/lib/server/copilot/session.ts
+++ b/src/lib/server/copilot/session.ts
@@ -44,6 +44,13 @@ export interface CreateSessionOptions {
   configDir?: string;
   skillDirectories?: string[];
   disabledSkills?: string[];
+  customAgents?: Array<{
+    name: string;
+    displayName?: string;
+    description?: string;
+    tools?: string[];
+    prompt: string;
+  }>;
 }
 
 function buildZodSchema(params: Record<string, { type: string; description: string }>): z.ZodObject<Record<string, z.ZodTypeAny>> {
@@ -267,6 +274,10 @@ export async function createCopilotSession(
 
   if (options.disabledSkills && options.disabledSkills.length > 0) {
     sessionConfig.disabledSkills = options.disabledSkills;
+  }
+
+  if (options.customAgents && options.customAgents.length > 0) {
+    sessionConfig.customAgents = options.customAgents;
   }
 
   return client.createSession(sessionConfig);

--- a/src/lib/server/ws/handler.ts
+++ b/src/lib/server/ws/handler.ts
@@ -27,7 +27,7 @@ const VALID_MESSAGE_TYPES = new Set([
   'permission_response',
   'list_tools', 'list_agents', 'select_agent', 'deselect_agent',
   'get_quota', 'compact', 'list_sessions', 'resume_session',
-  'delete_session', 'get_session_detail', 'get_plan', 'update_plan', 'delete_plan',
+  'delete_session', 'get_session_detail', 'get_plan', 'update_plan', 'delete_plan', 'start_fleet',
 ]);
 const VALID_MODES = new Set(['interactive', 'plan', 'autopilot']);
 const VALID_REASONING = new Set(['low', 'medium', 'high', 'xhigh']);
@@ -118,7 +118,7 @@ function wireSessionEvents(session: any, entry: PoolEntry, sessionId?: string): 
     });
   });
   session.on('subagent.started', (event: any) => {
-    poolSend(entry, { type: 'subagent_start', agentName: event.data.agentName });
+    poolSend(entry, { type: 'subagent_start', agentName: event.data.agentName, description: event.data?.description });
   });
   session.on('subagent.completed', (event: any) => {
     poolSend(entry, { type: 'subagent_end', agentName: event.data.agentName });
@@ -187,6 +187,10 @@ function wireSessionEvents(session: any, entry: PoolEntry, sessionId?: string): 
   session.on('exit_plan_mode.completed', () => { poolSend(entry, { type: 'exit_plan_mode_completed' }); });
   session.on('session.idle', (event: any) => {
     poolSend(entry, { type: 'session_idle', backgroundTasks: event.data?.backgroundTasks });
+    const agents = event.data?.backgroundTasks?.agents;
+    if (Array.isArray(agents) && agents.length > 0) {
+      poolSend(entry, { type: 'fleet_status', agents });
+    }
   });
   session.on('session.task_complete', (event: any) => {
     poolSend(entry, { type: 'task_complete', summary: event.data?.summary });
@@ -576,6 +580,28 @@ export function setupWebSocket(
                 ? msg.disabledSkills.filter((s: unknown) => typeof s === 'string')
                 : undefined;
 
+              const customAgents = Array.isArray(msg.customAgents)
+                ? msg.customAgents
+                    .filter((a: unknown) => {
+                      if (!a || typeof a !== 'object') return false;
+                      const obj = a as Record<string, unknown>;
+                      return typeof obj.name === 'string' && typeof obj.prompt === 'string';
+                    })
+                    .slice(0, 10)
+                    .map((a: unknown) => {
+                      const obj = a as Record<string, unknown>;
+                      return {
+                        name: obj.name as string,
+                        displayName: typeof obj.displayName === 'string' ? obj.displayName : undefined,
+                        description: typeof obj.description === 'string' ? obj.description : undefined,
+                        tools: Array.isArray(obj.tools)
+                          ? (obj.tools as unknown[]).filter((t): t is string => typeof t === 'string')
+                          : undefined,
+                        prompt: obj.prompt as string,
+                      };
+                    })
+                : undefined;
+
               const skillDirectories = await getSkillDirectories();
 
               connectionEntry.session = await createCopilotSession(connectionEntry.client, githubToken, {
@@ -592,6 +618,7 @@ export function setupWebSocket(
                 configDir: config.copilotConfigDir,
                 skillDirectories,
                 disabledSkills,
+                customAgents,
               });
 
               wireSessionEvents(connectionEntry.session, connectionEntry, connectionEntry.session?.sessionId);
@@ -649,9 +676,11 @@ export function setupWebSocket(
               : undefined;
 
             connectionEntry.isProcessing = true;
+            const sendMode = msg.mode === 'immediate' || msg.mode === 'enqueue' ? msg.mode : undefined;
             await connectionEntry.session.send({
               prompt: content,
               ...(attachments?.length ? { attachments } : {}),
+              ...(sendMode ? { mode: sendMode } : {}),
             });
             break;
           }
@@ -1149,6 +1178,28 @@ export function setupWebSocket(
             } catch (err: any) {
               console.error('Delete plan error:', err.message);
               poolSend(connectionEntry, { type: 'error', message: `Failed to delete plan: ${err.message}` });
+            }
+            break;
+          }
+
+          case 'start_fleet': {
+            if (!connectionEntry.session) {
+              poolSend(connectionEntry, { type: 'error', message: 'No active session. Send new_session first.' });
+              return;
+            }
+            const prompt = typeof msg.prompt === 'string' ? msg.prompt.trim() : '';
+            if (!prompt || prompt.length > MAX_MESSAGE_LENGTH) {
+              poolSend(connectionEntry, { type: 'error', message: `Fleet prompt must be 1-${MAX_MESSAGE_LENGTH} characters` });
+              return;
+            }
+            try {
+              connectionEntry.isProcessing = true;
+              const result = await connectionEntry.session.rpc.fleet.start({ prompt });
+              poolSend(connectionEntry, { type: 'fleet_started', started: result.started });
+            } catch (err: any) {
+              console.error('Fleet start error:', err.message);
+              connectionEntry.isProcessing = false;
+              poolSend(connectionEntry, { type: 'error', message: `Failed to start fleet: ${err.message}` });
             }
             break;
           }

--- a/src/lib/stores/chat.svelte.ts
+++ b/src/lib/stores/chat.svelte.ts
@@ -37,6 +37,8 @@ export interface ChatStore {
   readonly currentModel: string;
   readonly reasoningEffort: ReasoningEffort | null;
   readonly currentAgent: string | null;
+  readonly fleetActive: boolean;
+  readonly fleetAgents: Array<{ agentId: string; agentType: string; status: 'running' | 'completed' | 'failed'; error?: string }>;
   readonly sessionTitle: string | null;
   readonly pendingUserInput: UserInputState | null;
   readonly pendingPermission: PermissionRequestState | null;
@@ -59,6 +61,7 @@ export interface ChatStore {
   // Derived
   readonly isConnected: boolean;
   readonly canSend: boolean;
+  readonly canInterrupt: boolean;
 
   // Methods
   handleServerMessage(msg: ServerMessage): void;
@@ -88,6 +91,9 @@ export function createChatStore(wsStore: WsStore): ChatStore {
   let currentModel = $state('');
   let reasoningEffort = $state<ReasoningEffort | null>(null);
   let currentAgent = $state<string | null>(null);
+  let fleetActive = $state(false);
+  let currentFleetMessageId = $state<string | null>(null);
+  let fleetAgents = $state<Array<{ agentId: string; agentType: string; status: 'running' | 'completed' | 'failed'; error?: string }>>([]);
   let sessionTitle = $state<string | null>(null);
   let currentSessionId = $state<string | null>(null);
   let pendingUserInput = $state<UserInputState | null>(null);
@@ -117,11 +123,12 @@ export function createChatStore(wsStore: WsStore): ChatStore {
 
   // ── Derived values ──────────────────────────────────────────────────────
   const isConnected = $derived(wsStore.connectionState === 'connected');
-  const canSend = $derived(isConnected && !isStreaming && wsStore.sessionReady);
+  const canSend = $derived(isConnected && wsStore.sessionReady);
+  const canInterrupt = $derived(isWaiting || isReasoningStreaming || isStreaming);
 
   // ── Internal helpers ────────────────────────────────────────────────────
 
-  function addMessage(role: ChatMessageRole, content: string, extra?: Partial<ChatMessage>): void {
+  function addMessage(role: ChatMessageRole, content: string, extra?: Partial<ChatMessage>): ChatMessage {
     const msg: ChatMessage = {
       id: genId(),
       role,
@@ -130,10 +137,25 @@ export function createChatStore(wsStore: WsStore): ChatStore {
       ...extra,
     };
     messages = [...messages, msg];
+    return msg;
   }
 
   function addInfoMessage(content: string): void {
     addMessage('info', content);
+  }
+
+  function syncFleetMessage(content?: string): void {
+    if (!currentFleetMessageId) return;
+    const nextFleetAgents = fleetAgents.map((agent) => ({ ...agent }));
+    messages = messages.map(message =>
+      message.id === currentFleetMessageId
+        ? {
+            ...message,
+            content: content ?? message.content,
+            fleetAgents: nextFleetAgents,
+          }
+        : message,
+    );
   }
 
   function finalizeStream(): void {
@@ -489,16 +511,83 @@ export function createChatStore(wsStore: WsStore): ChatStore {
         addMessage('skill', msg.skillName, { skillName: msg.skillName });
         break;
 
+      case 'fleet_started':
+        fleetActive = msg.started;
+        if (msg.started) {
+          fleetAgents = [];
+          const fleetMessage = addMessage('fleet', 'Fleet mode activated — parallel agents are working', {
+            fleetAgents: [],
+          });
+          currentFleetMessageId = fleetMessage.id;
+        } else {
+          currentFleetMessageId = null;
+        }
+        break;
+
+      case 'fleet_status':
+        if (Array.isArray(msg.agents)) {
+          const nextFleetAgents = [...fleetAgents];
+          for (const agent of msg.agents) {
+            const existingIndex = nextFleetAgents.findIndex(a => a.agentId === agent.agentId);
+            if (existingIndex === -1) {
+              nextFleetAgents.push({ ...agent, status: 'running' });
+            } else {
+              nextFleetAgents[existingIndex] = {
+                ...nextFleetAgents[existingIndex],
+                agentType: agent.agentType,
+              };
+            }
+          }
+          fleetAgents = nextFleetAgents;
+          syncFleetMessage();
+        }
+        break;
+
       case 'subagent_start':
         addMessage('subagent', `${msg.agentName} started`, { agentName: msg.agentName });
+        if (fleetActive) {
+          const exists = fleetAgents.some(a => a.agentId === msg.agentName);
+          if (!exists) {
+            fleetAgents = [...fleetAgents, { agentId: msg.agentName, agentType: msg.agentName, status: 'running' }];
+          }
+          syncFleetMessage();
+        }
         break;
 
       case 'subagent_end':
         addMessage('subagent', `${msg.agentName} completed`, { agentName: msg.agentName });
+        if (fleetActive) {
+          fleetAgents = fleetAgents.map(a =>
+            a.agentId === msg.agentName ? { ...a, status: 'completed' as const } : a
+          );
+          if (fleetAgents.length > 0 && fleetAgents.every(a => a.status !== 'running')) {
+            const completed = fleetAgents.filter(a => a.status === 'completed').length;
+            const failed = fleetAgents.filter(a => a.status === 'failed').length;
+            syncFleetMessage(`Fleet complete: ${completed} succeeded, ${failed} failed`);
+            fleetActive = false;
+            currentFleetMessageId = null;
+          } else {
+            syncFleetMessage();
+          }
+        }
         break;
 
       case 'subagent_failed':
         addMessage('error', `Sub-agent ${msg.agentName ?? 'unknown'} failed${msg.error ? `: ${msg.error}` : ''}`);
+        if (fleetActive) {
+          fleetAgents = fleetAgents.map(a =>
+            a.agentId === (msg.agentName ?? 'unknown') ? { ...a, status: 'failed' as const, error: msg.error } : a
+          );
+          if (fleetAgents.length > 0 && fleetAgents.every(a => a.status !== 'running')) {
+            const completed = fleetAgents.filter(a => a.status === 'completed').length;
+            const failed = fleetAgents.filter(a => a.status === 'failed').length;
+            syncFleetMessage(`Fleet complete: ${completed} succeeded, ${failed} failed`);
+            fleetActive = false;
+            currentFleetMessageId = null;
+          } else {
+            syncFleetMessage();
+          }
+        }
         break;
 
       case 'subagent_selected':
@@ -600,6 +689,9 @@ export function createChatStore(wsStore: WsStore): ChatStore {
     currentStreamContent = '';
     currentReasoningContent = '';
     activeToolCalls = new Map();
+    fleetActive = false;
+    currentFleetMessageId = null;
+    fleetAgents = [];
     sessionTitle = null;
     currentSessionId = null;
     pendingUserInput = null;
@@ -637,6 +729,8 @@ export function createChatStore(wsStore: WsStore): ChatStore {
     get currentModel() { return currentModel; },
     get reasoningEffort() { return reasoningEffort; },
     get currentAgent() { return currentAgent; },
+    get fleetActive() { return fleetActive; },
+    get fleetAgents() { return fleetAgents; },
     get sessionTitle() { return sessionTitle; },
     get pendingUserInput() { return pendingUserInput; },
     get pendingPermission() { return pendingPermission; },
@@ -655,6 +749,7 @@ export function createChatStore(wsStore: WsStore): ChatStore {
 
     get isConnected() { return isConnected; },
     get canSend() { return canSend; },
+    get canInterrupt() { return canInterrupt; },
 
     handleServerMessage,
     clearMessages,

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -32,6 +32,7 @@ function createWsStoreMock(options: {
     connect: vi.fn(),
     disconnect: vi.fn(),
     onMessage: vi.fn(() => () => {}),
+    send: vi.fn(),
     sendMessage: vi.fn(),
     newSession: vi.fn(),
     resumeSession: vi.fn(),
@@ -128,6 +129,7 @@ describe('createChatStore', () => {
       { type: 'reasoning_delta', reasoningId: 'reason-1', content: ' deeply' },
     );
 
+    expect(store.canSend).toBe(true);
     expect(store.isWaiting).toBe(false);
     expect(store.isReasoningStreaming).toBe(true);
     expect(store.currentReasoningContent).toBe('Thinking deeply');
@@ -145,6 +147,7 @@ describe('createChatStore', () => {
     );
 
     expect(store.isStreaming).toBe(true);
+    expect(store.canSend).toBe(true);
     expect(store.currentStreamContent).toBe('Hello world');
 
     dispatch(store, { type: 'done' });
@@ -416,6 +419,80 @@ describe('createChatStore', () => {
       expect.objectContaining({ role: 'info', content: 'Exiting plan mode…' }),
       expect.objectContaining({ role: 'info', content: 'Exited plan mode' }),
     ]);
+  });
+
+  it('handles fleet_started message', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    store.handleServerMessage({ type: 'fleet_started', started: true });
+
+    expect(store.fleetActive).toBe(true);
+    const fleetMsg = store.messages.find(message => message.role === 'fleet');
+    expect(fleetMsg).toBeDefined();
+    expect(fleetMsg!.content).toContain('Fleet mode activated');
+  });
+
+  it('tracks fleet agents through subagent lifecycle', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    dispatch(
+      store,
+      { type: 'fleet_started', started: true },
+      { type: 'subagent_start', agentName: 'researcher' },
+    );
+
+    expect(store.fleetAgents).toHaveLength(1);
+    expect(store.fleetAgents[0].status).toBe('running');
+
+    store.handleServerMessage({ type: 'subagent_end', agentName: 'researcher' });
+
+    expect(store.fleetAgents[0].status).toBe('completed');
+  });
+
+  it('marks fleet complete when all agents finish', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    dispatch(
+      store,
+      { type: 'fleet_started', started: true },
+      { type: 'subagent_start', agentName: 'agent1' },
+      { type: 'subagent_start', agentName: 'agent2' },
+      { type: 'subagent_end', agentName: 'agent1' },
+    );
+
+    expect(store.fleetActive).toBe(true);
+
+    store.handleServerMessage({ type: 'subagent_end', agentName: 'agent2' });
+
+    expect(store.fleetActive).toBe(false);
+    const completeMsg = store.messages.find(
+      message => message.role === 'fleet' && message.content.includes('complete'),
+    );
+    expect(completeMsg).toBeDefined();
+  });
+
+  it('handles fleet agent failures', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    dispatch(
+      store,
+      { type: 'fleet_started', started: true },
+      { type: 'subagent_start', agentName: 'agent1' },
+      { type: 'subagent_failed', agentName: 'agent1', error: 'timeout' },
+    );
+
+    expect(store.fleetAgents[0].status).toBe('failed');
+    expect(store.fleetAgents[0].error).toBe('timeout');
+  });
+
+  it('resets fleet state on clearMessages', () => {
+    const store = createChatStore(createWsStoreMock());
+
+    store.handleServerMessage({ type: 'fleet_started', started: true });
+    store.clearMessages();
+
+    expect(store.fleetActive).toBe(false);
+    expect(store.fleetAgents).toHaveLength(0);
   });
 
   it('accumulates session usage totals across multiple usage messages', () => {

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -3,6 +3,7 @@ import type {
   ReasoningEffort,
   PersistedSettings,
   CustomToolDefinition,
+  CustomAgentDefinition,
   McpServerDefinition,
   SkillDefinition,
 } from '$lib/types/index.js';
@@ -16,6 +17,7 @@ const DEFAULT_SETTINGS: PersistedSettings = {
   customInstructions: '',
   excludedTools: [],
   customTools: [],
+  customAgents: [],
   mcpServers: [],
   disabledSkills: [],
 };
@@ -36,6 +38,18 @@ function isValidCustomTool(t: unknown): t is CustomToolDefinition {
   );
 }
 
+function isValidCustomAgent(agent: unknown): agent is CustomAgentDefinition {
+  if (!agent || typeof agent !== 'object') return false;
+  const obj = agent as Record<string, unknown>;
+  return (
+    typeof obj.name === 'string' &&
+    (typeof obj.displayName === 'undefined' || typeof obj.displayName === 'string') &&
+    (typeof obj.description === 'undefined' || typeof obj.description === 'string') &&
+    (typeof obj.tools === 'undefined' || (Array.isArray(obj.tools) && obj.tools.every((tool) => typeof tool === 'string'))) &&
+    typeof obj.prompt === 'string'
+  );
+}
+
 function isValidMcpServer(s: unknown): s is McpServerDefinition {
   if (!s || typeof s !== 'object') return false;
   const obj = s as Record<string, unknown>;
@@ -53,6 +67,7 @@ export interface SettingsStore {
   customInstructions: string;
   excludedTools: string[];
   customTools: CustomToolDefinition[];
+  customAgents: CustomAgentDefinition[];
   reasoningEffort: ReasoningEffort;
   selectedModel: string;
   selectedMode: SessionMode;
@@ -69,6 +84,7 @@ export function createSettingsStore(): SettingsStore {
   let customInstructions = $state(DEFAULT_SETTINGS.customInstructions);
   let excludedTools = $state<string[]>([...DEFAULT_SETTINGS.excludedTools]);
   let customTools = $state<CustomToolDefinition[]>([...DEFAULT_SETTINGS.customTools]);
+  let customAgents = $state<CustomAgentDefinition[]>([...(DEFAULT_SETTINGS.customAgents ?? [])]);
   let reasoningEffort = $state<ReasoningEffort>(DEFAULT_SETTINGS.reasoningEffort);
   let selectedModel = $state(DEFAULT_SETTINGS.model);
   let selectedMode = $state<SessionMode>(DEFAULT_SETTINGS.mode);
@@ -96,6 +112,7 @@ export function createSettingsStore(): SettingsStore {
       customInstructions,
       excludedTools,
       customTools,
+      customAgents,
       mcpServers,
       disabledSkills,
     };
@@ -117,6 +134,9 @@ export function createSettingsStore(): SettingsStore {
     }
     if (Array.isArray(parsed.customTools)) {
       customTools = parsed.customTools.filter(isValidCustomTool).slice(0, 10);
+    }
+    if (Array.isArray(parsed.customAgents)) {
+      customAgents = parsed.customAgents.filter(isValidCustomAgent).slice(0, 10);
     }
     if (Array.isArray(parsed.mcpServers)) {
       mcpServers = parsed.mcpServers.filter(isValidMcpServer).slice(0, 10);
@@ -191,6 +211,9 @@ export function createSettingsStore(): SettingsStore {
 
     get customTools() { return customTools; },
     set customTools(v: CustomToolDefinition[]) { customTools = v.slice(0, 10); save(); },
+
+    get customAgents() { return customAgents; },
+    set customAgents(v: CustomAgentDefinition[]) { customAgents = v.slice(0, 10); save(); },
 
     get reasoningEffort() { return reasoningEffort; },
     set reasoningEffort(v: ReasoningEffort) { reasoningEffort = v; save(); },

--- a/src/lib/stores/settings.test.ts
+++ b/src/lib/stores/settings.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSettingsStore } from '$lib/stores/settings.svelte.js';
-import type { CustomToolDefinition, McpServerDefinition, PersistedSettings } from '$lib/types/index.js';
+import type {
+  CustomAgentDefinition,
+  CustomToolDefinition,
+  McpServerDefinition,
+  PersistedSettings,
+} from '$lib/types/index.js';
 
 const STORAGE_KEY = 'copilot-cli-settings';
 
@@ -21,6 +26,16 @@ function makeCustomTool(name: string): CustomToolDefinition {
     parameters: {
       prompt: { type: 'string', description: 'Prompt text' },
     },
+  };
+}
+
+function makeCustomAgent(name: string): CustomAgentDefinition {
+  return {
+    name,
+    displayName: `${name} display`,
+    description: `${name} description`,
+    tools: [`${name}.tool`],
+    prompt: `Prompt for ${name}`,
   };
 }
 
@@ -53,12 +68,14 @@ describe('createSettingsStore', () => {
     expect(store.customInstructions).toBe('');
     expect(store.excludedTools).toEqual([]);
     expect(store.customTools).toEqual([]);
+    expect(store.customAgents).toEqual([]);
     expect(store.mcpServers).toEqual([]);
   });
 
   it('persists setter updates to localStorage and syncs them to the server', () => {
     const store = createSettingsStore();
     const tools = Array.from({ length: 12 }, (_, index) => makeCustomTool(`tool-${index}`));
+    const agents = Array.from({ length: 12 }, (_, index) => makeCustomAgent(`agent-${index}`));
     const servers = Array.from({ length: 12 }, (_, index) => makeMcpServer(`server-${index}`));
 
     store.selectedModel = 'gpt-5';
@@ -67,11 +84,13 @@ describe('createSettingsStore', () => {
     store.customInstructions = 'Be concise';
     store.excludedTools = ['bash', 'grep'];
     store.customTools = tools;
+    store.customAgents = agents;
     store.mcpServers = servers;
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as PersistedSettings;
 
     expect(store.customTools).toHaveLength(10);
+    expect(store.customAgents).toHaveLength(10);
     expect(store.mcpServers).toHaveLength(10);
     expect(persisted).toMatchObject({
       model: 'gpt-5',
@@ -81,8 +100,9 @@ describe('createSettingsStore', () => {
       excludedTools: ['bash', 'grep'],
     });
     expect(persisted.customTools).toHaveLength(10);
+    expect(persisted.customAgents).toHaveLength(10);
     expect(persisted.mcpServers).toHaveLength(10);
-    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
     expect(fetchMock).toHaveBeenLastCalledWith('/api/settings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -90,8 +110,29 @@ describe('createSettingsStore', () => {
     });
   });
 
+  it('persists custom agents in settings', () => {
+    const settings = createSettingsStore();
+
+    settings.customAgents = [
+      {
+        name: 'researcher',
+        prompt: 'You are a research assistant',
+        description: 'Research agent',
+      },
+    ];
+    settings.save();
+
+    const settings2 = createSettingsStore();
+    settings2.load();
+
+    expect(settings2.customAgents).toHaveLength(1);
+    expect(settings2.customAgents[0].name).toBe('researcher');
+    expect(settings2.customAgents[0].prompt).toBe('You are a research assistant');
+  });
+
   it('loads valid persisted settings, filters invalid entries, and keeps mode interactive', () => {
     const validTool = makeCustomTool('valid-tool');
+    const validAgent = makeCustomAgent('valid-agent');
     const validServer = makeMcpServer('valid-server');
 
     localStorage.setItem(
@@ -106,6 +147,11 @@ describe('createSettingsStore', () => {
           validTool,
           { ...validTool, name: 123 },
           ...Array.from({ length: 10 }, (_, index) => makeCustomTool(`extra-tool-${index}`)),
+        ],
+        customAgents: [
+          validAgent,
+          { ...validAgent, prompt: 123 },
+          ...Array.from({ length: 10 }, (_, index) => makeCustomAgent(`extra-agent-${index}`)),
         ],
         mcpServers: [
           validServer,
@@ -125,6 +171,8 @@ describe('createSettingsStore', () => {
     expect(store.excludedTools).toEqual(['bash']);
     expect(store.customTools).toHaveLength(10);
     expect(store.customTools[0]).toEqual(validTool);
+    expect(store.customAgents).toHaveLength(10);
+    expect(store.customAgents[0]).toEqual(validAgent);
     expect(store.mcpServers).toHaveLength(10);
     expect(store.mcpServers[0]).toEqual(validServer);
   });
@@ -150,6 +198,7 @@ describe('createSettingsStore', () => {
           customInstructions: 'Server wins',
           excludedTools: ['bash'],
           customTools: [makeCustomTool('server-tool')],
+          customAgents: [makeCustomAgent('server-agent')],
           mcpServers: [makeMcpServer('server-mcp')],
         },
       }),
@@ -165,6 +214,7 @@ describe('createSettingsStore', () => {
     expect(store.customInstructions).toBe('Server wins');
     expect(store.excludedTools).toEqual(['bash']);
     expect(store.customTools).toEqual([makeCustomTool('server-tool')]);
+    expect(store.customAgents).toEqual([makeCustomAgent('server-agent')]);
     expect(store.mcpServers).toEqual([makeMcpServer('server-mcp')]);
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as PersistedSettings;
@@ -192,6 +242,7 @@ describe('createSettingsStore', () => {
           customInstructions: '',
           excludedTools: [],
           customTools: [],
+          customAgents: [],
           mcpServers: [],
           disabledSkills: [],
         },

--- a/src/lib/stores/ws.svelte.ts
+++ b/src/lib/stores/ws.svelte.ts
@@ -5,6 +5,7 @@ import type {
   ClientMessage,
   ServerMessage,
   NewSessionConfig,
+  MessageDeliveryMode,
 } from '$lib/types/index.js';
 import { notify } from '$lib/utils/notifications.js';
 
@@ -30,8 +31,14 @@ export interface WsStore {
   disconnect(): void;
   onMessage(handler: (msg: ServerMessage) => void): () => void;
 
+  send(data: ClientMessage): void;
+
   // Typed send helpers
-  sendMessage(content: string, attachments?: Array<{ path: string; name: string; type: string }>): void;
+  sendMessage(
+    content: string,
+    attachments?: Array<{ path: string; name: string; type: string }>,
+    mode?: MessageDeliveryMode,
+  ): void;
   newSession(config: NewSessionConfig): void;
   resumeSession(sessionId: string): void;
   setMode(mode: SessionMode): void;
@@ -211,8 +218,17 @@ export function createWsStore(): WsStore {
 
   // ── Typed send functions ────────────────────────────────────────────────
 
-  function sendMessage(content: string, attachments?: Array<{ path: string; name: string; type: string }>): void {
-    send({ type: 'message', content, ...(attachments?.length ? { attachments } : {}) });
+  function sendMessage(
+    content: string,
+    attachments?: Array<{ path: string; name: string; type: string }>,
+    mode?: MessageDeliveryMode,
+  ): void {
+    send({
+      type: 'message',
+      content,
+      ...(attachments?.length ? { attachments } : {}),
+      ...(mode ? { mode } : {}),
+    });
   }
 
   function newSession(config: NewSessionConfig): void {
@@ -225,6 +241,7 @@ export function createWsStore(): WsStore {
       ...(config.customInstructions?.trim() && { customInstructions: config.customInstructions.trim() }),
       ...(config.excludedTools?.length && { excludedTools: config.excludedTools }),
       ...(config.customTools?.length && { customTools: config.customTools }),
+      ...(config.customAgents?.length && { customAgents: config.customAgents }),
       ...(config.mcpServers?.length && { mcpServers: config.mcpServers }),
       ...(config.disabledSkills?.length && { disabledSkills: config.disabledSkills }),
     };
@@ -325,6 +342,7 @@ export function createWsStore(): WsStore {
     disconnect,
     onMessage,
 
+    send,
     sendMessage,
     newSession,
     resumeSession,

--- a/src/lib/stores/ws.test.ts
+++ b/src/lib/stores/ws.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWsStore } from '$lib/stores/ws.svelte.js';
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+}));
+
+vi.mock('$lib/utils/notifications.js', () => ({
+  notify: notifyMock,
+}));
+
+const sockets: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  readonly url: string;
+  readyState = MockWebSocket.OPEN;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this);
+  }
+}
+
+describe('createWsStore', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    notifyMock.mockReset();
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it.each(['immediate', 'enqueue'] as const)('sends message delivery mode %s', (mode) => {
+    const store = createWsStore();
+    store.connect();
+
+    store.sendMessage('Ship it', undefined, mode);
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].send).toHaveBeenCalledWith(JSON.stringify({
+      type: 'message',
+      content: 'Ship it',
+      mode,
+    }));
+  });
+
+  it('passes custom agents when creating a new session', () => {
+    const store = createWsStore();
+    store.connect();
+    const customAgents = [
+      { name: 'researcher', prompt: 'Research the codebase', description: 'Research agent' },
+    ];
+
+    store.newSession({
+      model: 'gpt-4.1',
+      customAgents,
+    });
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].send).toHaveBeenCalledWith(JSON.stringify({
+      type: 'new_session',
+      model: 'gpt-4.1',
+      customAgents,
+    }));
+  });
+});

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -365,6 +365,7 @@ export interface SkillInvokedMessage {
 export interface SubagentStartMessage {
   type: 'subagent_start';
   agentName: string;
+  description?: string;
 }
 
 export interface SubagentEndMessage {
@@ -473,6 +474,16 @@ export interface WorkspaceFileChangedMessage {
   operation: 'create' | 'update';
 }
 
+export interface FleetStartedMessage {
+  type: 'fleet_started';
+  started: boolean;
+}
+
+export interface FleetStatusMessage {
+  type: 'fleet_status';
+  agents: Array<{ agentId: string; agentType: string }>;
+}
+
 export interface SessionUsageTotals {
   inputTokens: number;
   outputTokens: number;
@@ -543,7 +554,9 @@ export type ServerMessage =
   | TruncationMessage
   | ToolPartialResultMessage
   | ContextChangedMessage
-  | WorkspaceFileChangedMessage;
+  | WorkspaceFileChangedMessage
+  | FleetStartedMessage
+  | FleetStatusMessage;
 
 // ─── File attachment ─────────────────────────────────────────────────────────
 
@@ -566,12 +579,16 @@ export interface NewSessionMessage {
   customTools?: CustomToolDefinition[];
   mcpServers?: McpServerDefinition[];
   disabledSkills?: string[];
+  customAgents?: CustomAgentDefinition[];
 }
+
+export type MessageDeliveryMode = 'immediate' | 'enqueue';
 
 export interface SendMessage {
   type: 'message';
   content: string;
   attachments?: Array<{ path: string; name: string; type: string }>;
+  mode?: MessageDeliveryMode;
 }
 
 export interface ListModelsMessage {
@@ -665,6 +682,11 @@ export interface UpdatePlanMessage {
   content: string;
 }
 
+export interface StartFleetMessage {
+  type: 'start_fleet';
+  prompt: string;
+}
+
 export interface DeletePlanMessage {
   type: 'delete_plan';
 }
@@ -691,7 +713,8 @@ export type ClientMessage =
   | GetSessionDetailMessage
   | GetPlanMessage
   | UpdatePlanMessage
-  | DeletePlanMessage;
+  | DeletePlanMessage
+  | StartFleetMessage;
 
 // ─── Chat message type for rendering ────────────────────────────────────────
 
@@ -706,6 +729,7 @@ export type ChatMessageRole =
   | 'usage'
   | 'skill'
   | 'subagent'
+  | 'fleet'
   | 'reasoning';
 
 export interface ChatMessage {
@@ -722,6 +746,7 @@ export interface ChatMessage {
   mcpToolName?: string;
   agentName?: string;
   skillName?: string;
+  fleetAgents?: Array<{ agentId: string; agentType: string; status: 'running' | 'completed' | 'failed'; error?: string }>;
   inputTokens?: number;
   outputTokens?: number;
   reasoningTokens?: number;
@@ -792,6 +817,7 @@ export interface NewSessionConfig {
   customTools?: CustomToolDefinition[];
   mcpServers?: McpServerDefinition[];
   disabledSkills?: string[];
+  customAgents?: CustomAgentDefinition[];
 }
 
 // ─── Settings (persisted to localStorage) ───────────────────────────────────
@@ -805,6 +831,17 @@ export interface PersistedSettings {
   customTools: CustomToolDefinition[];
   mcpServers?: McpServerDefinition[];
   disabledSkills?: string[];
+  customAgents?: CustomAgentDefinition[];
+}
+
+// ─── Custom agent definitions ───────────────────────────────────────────────
+
+export interface CustomAgentDefinition {
+  name: string;
+  displayName?: string;
+  description?: string;
+  tools?: string[];
+  prompt: string;
 }
 
 // ─── Skill definitions ──────────────────────────────────────────────────────

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -141,14 +141,25 @@
       ...(settings.customInstructions.trim() && { customInstructions: settings.customInstructions.trim() }),
       ...(settings.excludedTools.length > 0 && { excludedTools: settings.excludedTools }),
       ...(settings.customTools.length > 0 && { customTools: settings.customTools }),
+      ...(settings.customAgents.length > 0 && { customAgents: settings.customAgents }),
       ...(settings.mcpServers.length > 0 && { mcpServers: settings.mcpServers.filter(s => s.enabled) }),
       ...(settings.disabledSkills.length > 0 && { disabledSkills: settings.disabledSkills }),
     });
   }
 
   function handleSend(content: string, attachments?: Array<{ path: string; name: string; type: string }>): void {
+    if (content.startsWith('/fleet ')) {
+      const prompt = content.slice(7).trim();
+      if (prompt) {
+        chatStore.addUserMessage(content);
+        wsStore.send({ type: 'start_fleet', prompt });
+        return;
+      }
+    }
+
     chatStore.addUserMessage(content);
-    wsStore.sendMessage(content, attachments);
+    const mode = chatStore.isStreaming ? 'immediate' : undefined;
+    wsStore.sendMessage(content, attachments, mode);
   }
 
   function handleNewChat(): void {
@@ -316,6 +327,7 @@
       customInstructions={settings.customInstructions}
       excludedTools={settings.excludedTools}
       customTools={settings.customTools}
+      customAgents={settings.customAgents}
       mcpServers={settings.mcpServers}
       availableSkills={settings.availableSkills}
       disabledSkills={settings.disabledSkills}
@@ -329,6 +341,7 @@
         }
       }}
       onSaveCustomTools={(tools) => { settings.customTools = tools; }}
+      onSaveCustomAgents={(agents) => { settings.customAgents = agents; }}
       onSaveMcpServers={(servers) => { settings.mcpServers = servers; }}
       onToggleSkill={handleToggleSkill}
       onSelectAgent={(name) => wsStore.selectAgent(name)}


### PR DESCRIPTION
## Summary

Implements three related Copilot SDK features that work together for parallel sub-agent execution.

### Fleet Mode (#62)
- `start_fleet` WebSocket message → `session.rpc.fleet.start()`
- `FleetProgress.svelte` component with agent status cards (running/completed/failed)
- Enriched subagent lifecycle events with description field
- `session.idle` background tasks surfaced as `fleet_status` messages
- Fleet state tracking in chat store with completion summary
- `/fleet <prompt>` slash command in chat input

### Steering & Queueing (#54)
- `mode` field (`immediate`/`enqueue`) on message delivery
- Chat input stays enabled during streaming for mid-turn steering
- Auto-sets `mode: 'immediate'` when sending during active stream
- Dynamic placeholder: "Steer or queue a follow-up..."

### Custom Agents (#50)
- `customAgents` config passed through session creation to SDK
- Settings modal UI for defining agents (name, prompt, tools, description)
- Persisted in settings store with max 10 agents
- Agents forwarded on new session creation

## Testing
- 25 test files, 246 tests passing
- Unit tests for fleet lifecycle, steering modes, custom agent persistence
- `npm run check` ✅ `npm run build` ✅ `npm run test:unit` ✅

## Closes
- Closes #62
- Closes #50
- Closes #54