### PR TITLE
fix: improve /fleet discoverability with UI button and slash hint

### DIFF
--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -12,6 +12,7 @@
     onAbort: () => void;
     onSetMode: (mode: SessionMode) => void;
     onUserInputResponse: (answer: string, wasFreeform: boolean) => void;
+    onFleet?: (prompt: string) => void;
   }
 
   const MAX_LENGTH = 10_000;
@@ -34,6 +35,7 @@
     onAbort,
     onSetMode,
     onUserInputResponse,
+    onFleet,
   }: Props = $props();
 
   const modes: { value: SessionMode; label: string }[] = [
@@ -71,6 +73,10 @@
 
   const showSteeringIndicator = $derived(
     !pendingUserInput && isStreaming && inputValue.trim().length > 0,
+  );
+
+  const showSlashHint = $derived(
+    !pendingUserInput && inputValue === '/' && !isDisabled,
   );
 
   function autoResize() {
@@ -302,6 +308,15 @@
       onkeydown={handleKeydown}
     ></textarea>
 
+    {#if showSlashHint}
+      <div class="slash-hint" role="listbox" aria-label="Slash commands">
+        <button class="slash-option" role="option" aria-selected="false" onclick={() => { inputValue = '/fleet '; textareaEl?.focus(); }}>
+          <span class="slash-cmd">/fleet</span>
+          <span class="slash-desc">Run parallel sub-agents on a task</span>
+        </button>
+      </div>
+    {/if}
+
     {#if showSteeringIndicator}
       <div class="steering-indicator" role="status" aria-live="polite">
         Sending now will steer the current response.
@@ -370,6 +385,17 @@
               {m.label}
             </button>
           {/each}
+          {#if onFleet}
+            <button
+              class="mode-btn fleet-btn"
+              onclick={() => { inputValue = '/fleet '; textareaEl?.focus(); }}
+              disabled={isDisabled && !pendingUserInput}
+              aria-label="Fleet mode"
+              title="Parallel sub-agents: type /fleet followed by your task"
+            >
+              ⚡ Fleet
+            </button>
+          {/if}
         </div>
       </div>
 
@@ -542,6 +568,53 @@
     font-family: var(--font-mono);
     font-size: 0.75em;
     line-height: 1.4;
+  }
+
+  .slash-hint {
+    position: absolute;
+    bottom: 100%;
+    left: var(--sp-2);
+    right: var(--sp-2);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--sp-1);
+    margin-bottom: var(--sp-1);
+    z-index: 10;
+    animation: userInputIn 0.15s ease;
+  }
+
+  .slash-option {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    width: 100%;
+    padding: var(--sp-2) var(--sp-3);
+    border: none;
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--fg);
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.85em;
+  }
+
+  .slash-option:hover {
+    background: var(--bg-secondary);
+  }
+
+  .slash-cmd {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--purple);
+  }
+
+  .slash-desc {
+    color: var(--fg-muted);
+  }
+
+  .fleet-btn {
+    color: var(--purple) !important;
   }
 
   .toolbar-right {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -148,13 +148,19 @@
   }
 
   function handleSend(content: string, attachments?: Array<{ path: string; name: string; type: string }>): void {
-    if (content.startsWith('/fleet ')) {
-      const prompt = content.slice(7).trim();
-      if (prompt) {
+    const trimmed = content.trim();
+
+    // Handle /fleet command — with or without trailing space
+    if (trimmed === '/fleet' || trimmed.startsWith('/fleet ')) {
+      const prompt = trimmed.slice(6).trim();
+      if (!prompt) {
         chatStore.addUserMessage(content);
-        wsStore.send({ type: 'start_fleet', prompt });
+        chatStore.handleServerMessage({ type: 'error', message: 'Usage: /fleet <prompt> — describe the task for parallel agents' } as any);
         return;
       }
+      chatStore.addUserMessage(content);
+      wsStore.send({ type: 'start_fleet', prompt });
+      return;
     }
 
     chatStore.addUserMessage(content);
@@ -293,6 +299,10 @@
         onAbort={() => wsStore.abort()}
         onSetMode={handleSetMode}
         onUserInputResponse={handleUserInputResponse}
+        onFleet={(prompt) => {
+          chatStore.addUserMessage(`/fleet ${prompt}`);
+          wsStore.send({ type: 'start_fleet', prompt });
+        }}
       />
     </div>
 


### PR DESCRIPTION
## Problem
The `/fleet` slash command was hidden — no UI affordance, no hint. Typing `/fleet` alone (without a prompt) was silently sent as a regular message.

## Changes
- **⚡ Fleet button** in chat input toolbar (next to Ask/Plan/Agent modes)
- **Slash command hint**: typing `/` shows a popup with `/fleet` command and description
- **Usage hint**: typing `/fleet` without a prompt shows an error with usage instructions
- **Edge case fix**: `/fleet` parsing now handles with/without trailing space
- Wired `onFleet` callback from ChatInput → page

## Validation
`npm run check` ✅ `npm run build` ✅ `npm run test:unit` (246 tests) ✅