### PR TITLE
fix: switch to Agent mode when Fleet button is pressed

### DIFF
--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -388,10 +388,11 @@
           {#if onFleet}
             <button
               class="mode-btn fleet-btn"
-              onclick={() => { inputValue = '/fleet '; textareaEl?.focus(); }}
+              class:active={mode === 'autopilot' && inputValue.startsWith('/fleet')}
+              onclick={() => { onSetMode('autopilot'); inputValue = '/fleet '; textareaEl?.focus(); }}
               disabled={isDisabled && !pendingUserInput}
               aria-label="Fleet mode"
-              title="Parallel sub-agents: type /fleet followed by your task"
+              title="Switch to Agent mode and run parallel sub-agents"
             >
               ⚡ Fleet
             </button>


### PR DESCRIPTION
Fleet mode spawns parallel autonomous agents, so autopilot (Agent) mode is the natural context.

**Change**: clicking ⚡ Fleet now calls `onSetMode('autopilot')` before pre-filling `/fleet ` in the input. The button also highlights as active while composing a fleet prompt.