### PR TITLE
fix: guard writeHead against double-header crash on page refresh

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,6 +67,18 @@ const server = createServer((req, res) => {
       return origEnd(...args);
     };
 
+    const origSetHeader = res.setHeader.bind(res);
+    res.setHeader = function (...args) {
+      if (!res.headersSent) return origSetHeader(...args);
+      return res;
+    };
+
+    const origWriteHead = res.writeHead.bind(res);
+    res.writeHead = function (...args) {
+      if (!res.headersSent) return origWriteHead(...args);
+      return res;
+    };
+
     handler(req, res);
   });
 });


### PR DESCRIPTION
## Problem

`express-session`'s `on-headers` hook calls `writeHead` after SvelteKit's adapter-node has already sent headers, causing `ERR_HTTP_HEADERS_SENT` crashes on page refresh.

## Fix

Guard both `setHeader` and `writeHead` against double-invocation by checking `res.headersSent` before calling the original methods. This matches the existing `res.end` guard pattern already in `server.js`.