### PR TITLE
feat: inject and auto-refresh MCP OAuth tokens from CLI token store

### DIFF
--- a/src/lib/components/settings/McpServersPanel.svelte
+++ b/src/lib/components/settings/McpServersPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { ToolInfo, SourcedMcpServerInfo } from '$lib/types/index.js';
-  import SourceBadge from '$lib/components/shared/SourceBadge.svelte';
 
   interface Props {
     discoveredMcpServers: SourcedMcpServerInfo[];
@@ -47,17 +46,20 @@
 {:else if discoveredMcpServers.length > 0}
   {#each discoveredMcpServers as server (server.name)}
     {@const sessionTools = getMcpTools(server.name)}
+    {@const isAuthError = server.error?.includes('HTTP error') || server.error?.includes('401') || server.error?.includes('Streamable HTTP')}
+    {@const effectiveStatus = isAuthError && server.status === 'failed' ? 'auth_required' : server.status}
     <div class="mcp-server-item">
       <div class="mcp-server-header">
         <span class="mcp-server-name">{server.name}</span>
-        <SourceBadge source={server.source} />
         <span class="mcp-server-badge">{server.type || 'mcp'}</span>
-        {#if server.status && server.status !== 'not_configured'}
-          <span class="mcp-server-badge {server.status === 'connected' ? 'status-ok' : server.status === 'failed' ? 'status-err' : ''}">{server.status}</span>
+        {#if effectiveStatus && effectiveStatus !== 'not_configured'}
+          <span class="mcp-server-badge {effectiveStatus === 'connected' ? 'status-ok' : effectiveStatus === 'auth_required' ? 'status-warn' : effectiveStatus === 'failed' ? 'status-err' : ''}">{effectiveStatus === 'auth_required' ? 'needs auth' : effectiveStatus}</span>
         {/if}
       </div>
       <div class="tool-toggle-desc">{server.url || server.command || 'CLI-configured'}</div>
-      {#if server.error}
+      {#if isAuthError}
+        <div class="tool-toggle-desc" style="color: var(--warning, #d29922)">Run <code>copilot</code> CLI and use /mcp to authenticate this server.</div>
+      {:else if server.error}
         <div class="tool-toggle-desc" style="color: var(--danger)">{server.error}</div>
       {/if}
       {#if sessionTools.length > 0}
@@ -72,7 +74,7 @@
             To test this MCP, ask for one of these capabilities explicitly so the model has a clear reason to call it.
           </p>
         </div>
-      {:else if server.status === 'failed'}
+      {:else if effectiveStatus === 'failed'}
         <p class="settings-hint mcp-test-hint">
           This server is configured but failed to start, so it cannot expose tools to the current session yet.
         </p>
@@ -137,6 +139,7 @@
     border: 1px solid var(--border);
   }
   .mcp-server-badge.status-ok { color: var(--success, #3fb950); border-color: var(--success, #3fb950); }
+  .mcp-server-badge.status-warn { color: var(--warning, #d29922); border-color: var(--warning, #d29922); }
   .mcp-server-badge.status-err { color: var(--danger); border-color: var(--danger); }
   .mcp-tools-block {
     margin-top: var(--sp-2);

--- a/src/lib/components/settings/McpServersPanel.svelte
+++ b/src/lib/components/settings/McpServersPanel.svelte
@@ -72,6 +72,10 @@
             To test this MCP, ask for one of these capabilities explicitly so the model has a clear reason to call it.
           </p>
         </div>
+      {:else if effectiveStatus === 'connected'}
+        <p class="settings-hint mcp-test-hint">
+          Connected and available to the model. Tools are managed by the SDK and will be called when relevant.
+        </p>
       {:else if effectiveStatus === 'failed'}
         <p class="settings-hint mcp-test-hint">
           This server is configured but failed to start, so it cannot expose tools to the current session yet.

--- a/src/lib/components/settings/McpServersPanel.svelte
+++ b/src/lib/components/settings/McpServersPanel.svelte
@@ -57,9 +57,7 @@
         {/if}
       </div>
       <div class="tool-toggle-desc">{server.url || server.command || 'CLI-configured'}</div>
-      {#if isAuthError}
-        <div class="tool-toggle-desc" style="color: var(--warning, #d29922)">Run <code>copilot</code> CLI and use /mcp to authenticate this server.</div>
-      {:else if server.error}
+      {#if !isAuthError && server.error}
         <div class="tool-toggle-desc" style="color: var(--danger)">{server.error}</div>
       {/if}
       {#if sessionTools.length > 0}

--- a/src/lib/server/copilot/session.test.ts
+++ b/src/lib/server/copilot/session.test.ts
@@ -299,6 +299,7 @@ describe('createCopilotSession', () => {
       },
     }));
 
+    // Expired token with no config file for refresh
     await writeFile(join(oauthDir, `${hash}.tokens.json`), JSON.stringify({
       accessToken: 'expired-token',
       refreshToken: 'r',
@@ -317,6 +318,71 @@ describe('createCopilotSession', () => {
       );
     } finally {
       warnSpy.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes an expired OAuth token using the refresh_token grant', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'copilot-mcp-oauth-'));
+    const serverUrl = 'https://agent365.svc.cloud.microsoft/agents/tenants/test/servers/mcp_MailTools';
+    const hash = createHash('sha256').update(serverUrl).digest('hex');
+    const oauthDir = join(dir, 'mcp-oauth-config');
+    await mkdir(oauthDir, { recursive: true });
+
+    await writeFile(join(dir, 'mcp-config.json'), JSON.stringify({
+      mcpServers: {
+        'm365-mail': { type: 'http', url: serverUrl, headers: {} },
+      },
+    }));
+
+    // Expired token
+    await writeFile(join(oauthDir, `${hash}.tokens.json`), JSON.stringify({
+      accessToken: 'expired-token',
+      refreshToken: 'valid-refresh-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+      scope: 'https://agent365.svc.cloud.microsoft/.default',
+    }));
+
+    // OAuth config with authorization server details
+    await writeFile(join(oauthDir, `${hash}.json`), JSON.stringify({
+      serverUrl,
+      authorizationServerUrl: 'https://login.microsoftonline.com/organizations/v2.0',
+      clientId: 'test-client-id',
+      redirectUri: 'http://127.0.0.1:12345/',
+      resourceUrl: serverUrl,
+      issuedAt: 0,
+      isStatic: false,
+    }));
+
+    // Mock the token endpoint response
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: 'fresh-access-token',
+        refresh_token: 'fresh-refresh-token',
+        expires_in: 3600,
+        scope: 'https://agent365.svc.cloud.microsoft/.default',
+      }),
+    });
+
+    try {
+      const mcpServers = await buildSessionMcpServers('gh-token', dir);
+      const server = mcpServers['m365-mail'] as { headers?: Record<string, string> };
+      expect(server.headers?.Authorization).toBe('Bearer fresh-access-token');
+
+      // Verify fetch was called with correct params
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/organizations/oauth2/v2.0/token',
+        expect.objectContaining({ method: 'POST' }),
+      );
+
+      // Verify tokens were written back to disk
+      const { readFile: rf } = await import('node:fs/promises');
+      const updated = JSON.parse(await rf(join(oauthDir, `${hash}.tokens.json`), 'utf8'));
+      expect(updated.accessToken).toBe('fresh-access-token');
+      expect(updated.refreshToken).toBe('fresh-refresh-token');
+    } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/src/lib/server/copilot/session.test.ts
+++ b/src/lib/server/copilot/session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -225,6 +226,122 @@ describe('createCopilotSession', () => {
 
     const mcpServers = getSessionConfig(client).mcpServers as Record<string, Record<string, unknown>>;
     expect(Object.keys(mcpServers)).toEqual(['github']);
+  });
+
+  it('injects OAuth token from CLI token store for HTTP MCP servers without Authorization', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'copilot-mcp-oauth-'));
+    const serverUrl = 'https://agent365.svc.cloud.microsoft/agents/tenants/test/servers/mcp_MailTools';
+    const hash = createHash('sha256').update(serverUrl).digest('hex');
+    const oauthDir = join(dir, 'mcp-oauth-config');
+    await mkdir(oauthDir, { recursive: true });
+
+    await writeFile(join(dir, 'mcp-config.json'), JSON.stringify({
+      mcpServers: {
+        'm365-mail': { type: 'http', url: serverUrl, headers: {} },
+      },
+    }));
+
+    await writeFile(join(oauthDir, `${hash}.tokens.json`), JSON.stringify({
+      accessToken: 'test-m365-token',
+      refreshToken: 'test-refresh',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      scope: 'https://agent365.svc.cloud.microsoft/.default',
+    }));
+
+    try {
+      const mcpServers = await buildSessionMcpServers('gh-token', dir);
+      const mailServer = mcpServers['m365-mail'] as { headers?: Record<string, string> };
+      expect(mailServer.headers?.Authorization).toBe('Bearer test-m365-token');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not inject OAuth token when server already has an Authorization header', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'copilot-mcp-oauth-'));
+    const serverUrl = 'https://example.com/mcp';
+    const hash = createHash('sha256').update(serverUrl).digest('hex');
+    const oauthDir = join(dir, 'mcp-oauth-config');
+    await mkdir(oauthDir, { recursive: true });
+
+    await writeFile(join(dir, 'mcp-config.json'), JSON.stringify({
+      mcpServers: {
+        'custom-server': { type: 'http', url: serverUrl, headers: { Authorization: 'Bearer static-token' } },
+      },
+    }));
+
+    await writeFile(join(oauthDir, `${hash}.tokens.json`), JSON.stringify({
+      accessToken: 'should-not-be-used',
+      refreshToken: 'r',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      scope: 'test',
+    }));
+
+    try {
+      const mcpServers = await buildSessionMcpServers('gh-token', dir);
+      const server = mcpServers['custom-server'] as { headers?: Record<string, string> };
+      expect(server.headers?.Authorization).toBe('Bearer static-token');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns and skips injection when OAuth token is expired', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'copilot-mcp-oauth-'));
+    const serverUrl = 'https://agent365.svc.cloud.microsoft/agents/tenants/test/servers/mcp_CalendarTools';
+    const hash = createHash('sha256').update(serverUrl).digest('hex');
+    const oauthDir = join(dir, 'mcp-oauth-config');
+    await mkdir(oauthDir, { recursive: true });
+
+    await writeFile(join(dir, 'mcp-config.json'), JSON.stringify({
+      mcpServers: {
+        'm365-calendar': { type: 'http', url: serverUrl, headers: {} },
+      },
+    }));
+
+    await writeFile(join(oauthDir, `${hash}.tokens.json`), JSON.stringify({
+      accessToken: 'expired-token',
+      refreshToken: 'r',
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+      scope: 'test',
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const mcpServers = await buildSessionMcpServers('gh-token', dir);
+      const server = mcpServers['m365-calendar'] as { headers?: Record<string, string> };
+      expect(server.headers?.Authorization).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('expired'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('gracefully handles missing OAuth token files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'copilot-mcp-oauth-'));
+
+    await writeFile(join(dir, 'mcp-config.json'), JSON.stringify({
+      mcpServers: {
+        'm365-teams': {
+          type: 'http',
+          url: 'https://agent365.svc.cloud.microsoft/agents/tenants/test/servers/mcp_TeamsServer',
+          headers: {},
+        },
+      },
+    }));
+
+    try {
+      const mcpServers = await buildSessionMcpServers('gh-token', dir);
+      const server = mcpServers['m365-teams'] as { headers?: Record<string, string> };
+      expect(server.headers?.Authorization).toBeUndefined();
+      expect(mcpServers.github).toBeDefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('wires session hooks when onHookEvent callback is provided', async () => {

--- a/src/lib/server/copilot/session.ts
+++ b/src/lib/server/copilot/session.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { CopilotClient } from '@github/copilot-sdk';
 import type { SessionConfig, SystemPromptSection, SectionOverride, MCPServerConfig } from '@github/copilot-sdk';
 
@@ -129,6 +130,80 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+interface McpOAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  scope: string;
+}
+
+/**
+ * Reads M365 OAuth tokens managed by the Copilot CLI.
+ * The CLI stores tokens in ~/.copilot/mcp-oauth-config/{SHA256(serverUrl)}.tokens.json
+ * after the user authenticates via `copilot /mcp` → re-auth flow.
+ * Returns the access token if valid, or a warning message if expired/missing.
+ */
+async function loadCliOAuthToken(
+  serverUrl: string,
+  configDir: string,
+): Promise<{ token?: string; expired?: boolean }> {
+  const hash = createHash('sha256').update(serverUrl).digest('hex');
+  const tokensPath = join(configDir, 'mcp-oauth-config', `${hash}.tokens.json`);
+
+  try {
+    const raw = await readFile(tokensPath, 'utf8');
+    const tokens: McpOAuthTokens = JSON.parse(raw);
+
+    if (!tokens.accessToken) {
+      return {};
+    }
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (tokens.expiresAt && tokens.expiresAt <= nowSec) {
+      return { expired: true };
+    }
+
+    return { token: tokens.accessToken };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * For HTTP MCP servers that require OAuth (no static Authorization header),
+ * attempt to inject a bearer token from the Copilot CLI's token store.
+ */
+async function injectOAuthHeaders(
+  servers: Record<string, MCPServerConfig>,
+  configDir: string,
+): Promise<string[]> {
+  const warnings: string[] = [];
+
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.type !== 'http' && server.type !== 'sse') continue;
+
+    const httpServer = server as { url: string; headers?: Record<string, string> };
+    // Skip servers that already have an Authorization header
+    if (httpServer.headers?.Authorization || httpServer.headers?.authorization) continue;
+
+    const result = await loadCliOAuthToken(httpServer.url, configDir);
+
+    if (result.expired) {
+      warnings.push(
+        `[MCP] OAuth token for "${name}" has expired. Run \`copilot\` CLI and use /mcp → re-auth to refresh.`,
+      );
+      continue;
+    }
+
+    if (result.token) {
+      httpServer.headers = { ...httpServer.headers, Authorization: `Bearer ${result.token}` };
+      console.log(`[MCP] Injected OAuth token for "${name}" from CLI token store`);
+    }
+  }
+
+  return warnings;
+}
+
 async function loadConfiguredMcpServers(configDir?: string): Promise<Record<string, MCPServerConfig>> {
   const resolvedConfigDir = configDir || config.copilotConfigDir || join(homedir(), '.copilot');
   const configPath = join(resolvedConfigDir, 'mcp-config.json');
@@ -168,7 +243,8 @@ async function loadConfiguredMcpServers(configDir?: string): Promise<Record<stri
     }
 
     return result;
-  } catch {
+  } catch (err) {
+    console.error('[MCP] Failed to load configured MCP servers:', err instanceof Error ? err.message : err);
     return {};
   }
 }
@@ -177,7 +253,14 @@ export async function buildSessionMcpServers(
   githubToken: string,
   configDir?: string,
 ) : Promise<Record<string, MCPServerConfig>> {
+  const resolvedConfigDir = configDir || config.copilotConfigDir || join(homedir(), '.copilot');
   const configuredMcpServers = await loadConfiguredMcpServers(configDir);
+
+  // Inject OAuth tokens from the Copilot CLI's token store for HTTP servers
+  const warnings = await injectOAuthHeaders(configuredMcpServers, resolvedConfigDir);
+  for (const warning of warnings) {
+    console.warn(warning);
+  }
 
   return {
     ...configuredMcpServers,

--- a/src/lib/server/copilot/session.ts
+++ b/src/lib/server/copilot/session.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { readFile, readdir } from 'node:fs/promises';
+import { readFile, writeFile, rename } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { CopilotClient } from '@github/copilot-sdk';
 import type { SessionConfig, SystemPromptSection, SectionOverride, MCPServerConfig } from '@github/copilot-sdk';
@@ -137,11 +137,84 @@ interface McpOAuthTokens {
   scope: string;
 }
 
+interface McpOAuthConfig {
+  serverUrl: string;
+  authorizationServerUrl: string;
+  clientId: string;
+  redirectUri: string;
+  resourceUrl: string;
+  issuedAt: number;
+  isStatic: boolean;
+}
+
+/**
+ * Refreshes an expired OAuth token using the refresh_token grant.
+ * Writes the updated tokens back to the CLI's token store so both
+ * copilot-unleashed and the CLI stay in sync.
+ */
+async function refreshOAuthToken(
+  oauthConfig: McpOAuthConfig,
+  tokens: McpOAuthTokens,
+  tokensPath: string,
+): Promise<string | null> {
+  if (!tokens.refreshToken || !oauthConfig.clientId) return null;
+
+  // Derive token endpoint from authorization server URL
+  // authorizationServerUrl is e.g. "https://login.microsoftonline.com/organizations/v2.0"
+  const tokenUrl = oauthConfig.authorizationServerUrl.replace(/\/v2\.0\/?$/, '/oauth2/v2.0/token');
+
+  try {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: oauthConfig.clientId,
+      refresh_token: tokens.refreshToken,
+      scope: tokens.scope,
+    });
+
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      redirect: 'manual',
+    });
+
+    if (!response.ok) {
+      console.warn(`[MCP] Token refresh failed (${response.status}) for ${oauthConfig.serverUrl}`);
+      return null;
+    }
+
+    const data = await response.json() as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in: number;
+      scope?: string;
+    };
+
+    const refreshed: McpOAuthTokens = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token || tokens.refreshToken,
+      expiresAt: Math.floor(Date.now() / 1000) + data.expires_in,
+      scope: data.scope || tokens.scope,
+    };
+
+    // Write back atomically so CLI stays in sync
+    const tmpPath = tokensPath + '.tmp';
+    await writeFile(tmpPath, JSON.stringify(refreshed), 'utf8');
+    await rename(tmpPath, tokensPath);
+
+    console.log(`[MCP] Refreshed OAuth token for ${oauthConfig.serverUrl.replace(/.*servers\//, '')}`);
+    return refreshed.accessToken;
+  } catch (err) {
+    console.warn(`[MCP] Token refresh error:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
 /**
  * Reads M365 OAuth tokens managed by the Copilot CLI.
  * The CLI stores tokens in ~/.copilot/mcp-oauth-config/{SHA256(serverUrl)}.tokens.json
  * after the user authenticates via `copilot /mcp` → re-auth flow.
- * Returns the access token if valid, or a warning message if expired/missing.
+ * If the token is expired but a refresh token exists, attempts to refresh automatically.
  */
 async function loadCliOAuthToken(
   serverUrl: string,
@@ -149,6 +222,7 @@ async function loadCliOAuthToken(
 ): Promise<{ token?: string; expired?: boolean }> {
   const hash = createHash('sha256').update(serverUrl).digest('hex');
   const tokensPath = join(configDir, 'mcp-oauth-config', `${hash}.tokens.json`);
+  const configPath = join(configDir, 'mcp-oauth-config', `${hash}.json`);
 
   try {
     const raw = await readFile(tokensPath, 'utf8');
@@ -159,7 +233,19 @@ async function loadCliOAuthToken(
     }
 
     const nowSec = Math.floor(Date.now() / 1000);
-    if (tokens.expiresAt && tokens.expiresAt <= nowSec) {
+    // Refresh 2 minutes before expiry to avoid edge-case failures
+    if (tokens.expiresAt && tokens.expiresAt <= nowSec + 120) {
+      // Attempt refresh
+      try {
+        const configRaw = await readFile(configPath, 'utf8');
+        const oauthConfig: McpOAuthConfig = JSON.parse(configRaw);
+        const refreshed = await refreshOAuthToken(oauthConfig, tokens, tokensPath);
+        if (refreshed) {
+          return { token: refreshed };
+        }
+      } catch {
+        // Config file missing or unreadable - can't refresh
+      }
       return { expired: true };
     }
 
@@ -190,7 +276,7 @@ async function injectOAuthHeaders(
 
     if (result.expired) {
       warnings.push(
-        `[MCP] OAuth token for "${name}" has expired. Run \`copilot\` CLI and use /mcp → re-auth to refresh.`,
+        `[MCP] OAuth token for "${name}" has expired and refresh failed. Initial CLI auth via \`copilot /mcp\` may be needed.`,
       );
       continue;
     }

--- a/src/lib/utils/customization-helpers.ts
+++ b/src/lib/utils/customization-helpers.ts
@@ -20,7 +20,9 @@ export function normalizeCustomizationSource(raw: string | undefined): Customiza
       : 'builtin';
 }
 
-/** Merge incoming MCP server list with existing, deduplicating by name */
+/** Merge incoming MCP server list with existing, deduplicating by name.
+ *  Only overwrites fields when the incoming value is defined, and prefers
+ *  live status (connected/failed) over static status (not_configured). */
 export function mergeMcpServers(
   current: SourcedMcpServerInfo[],
   incoming: Array<{
@@ -38,10 +40,22 @@ export function mergeMcpServers(
   for (const server of incoming) {
     const key = server.name.toLowerCase();
     const existing = merged.get(key);
+
+    // Pick the more informative status: live status wins over static
+    const existingIsLive = existing?.status === 'connected' || existing?.status === 'failed' || existing?.status === 'auth_required';
+    const incomingIsLive = server.status === 'connected' || server.status === 'failed';
+    const status = incomingIsLive ? server.status
+      : existingIsLive ? existing!.status
+      : server.status || existing?.status || 'not_configured';
+
     merged.set(key, {
-      ...existing,
-      ...server,
+      name: server.name,
       source: normalizeCustomizationSource(server.source ?? existing?.source),
+      status,
+      type: server.type ?? existing?.type,
+      url: server.url ?? existing?.url,
+      command: server.command ?? existing?.command,
+      error: incomingIsLive ? server.error : (server.error ?? existing?.error),
     });
   }
 


### PR DESCRIPTION
## Problem

MCP servers that require OAuth tokens (e.g. Microsoft 365 Graph API) fail to connect because the app doesn't inject the tokens the Copilot CLI has already acquired and stored locally.

## Changes

### Token injection from CLI store (`session.ts`)
- Read OAuth tokens from `~/.copilot/mcp-oauth-config/{hash}.tokens.json` at session creation
- Inject valid tokens as `Authorization` headers into MCP server environment
- Hash-based lookup matches the CLI's own token storage convention

### Auto-refresh expired tokens (`session.ts`)
- Detect expired OAuth tokens via `expires_at` field
- Use the stored `refresh_token` to acquire new access tokens from the OAuth provider
- Write refreshed tokens back to the CLI's token store so both CLI and browser stay in sync

### Settings panel improvements (`McpServersPanel.svelte`, `customization-helpers.ts`)
- Show connected/disconnected status for OAuth-requiring servers
- Fix merge logic when combining SDK-discovered and config-file MCP servers
- Improve display of servers that need OAuth setup

### Tests
- 4 new test cases covering token injection, refresh flow, and error handling