### PR TITLE
fix: use platform path separator in attachment validation

### DIFF
--- a/src/lib/server/ws/attachment-validation.test.ts
+++ b/src/lib/server/ws/attachment-validation.test.ts
@@ -43,7 +43,7 @@ describe('isValidAttachmentPath', () => {
 
 	it('rejects paths that match the prefix as a substring but are not inside it', () => {
 		// e.g. /tmp/copilot-uploads-evil/file.txt should not match /tmp/copilot-uploads/
-		expect(isValidAttachmentPath(UPLOAD_PREFIX + '-evil/file.txt')).toBe(false);
+		expect(isValidAttachmentPath(join(UPLOAD_PREFIX + '-evil', 'file.txt'))).toBe(false);
 	});
 });
 

--- a/src/lib/server/ws/attachments.ts
+++ b/src/lib/server/ws/attachments.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { logSecurity } from '../security-log.js';
 import { UPLOAD_DIR_PREFIX } from './constants.js';
 
@@ -12,7 +12,7 @@ export type SdkAttachment =
 /** Validate that an attachment path is an absolute path inside the upload directory (prevents arbitrary file reads). */
 export function isValidAttachmentPath(filePath: string): boolean {
   const resolved = resolve(filePath);
-  return resolved.startsWith(UPLOAD_DIR_PREFIX + '/');
+  return resolved.startsWith(UPLOAD_DIR_PREFIX + sep);
 }
 
 /** Map client-sent attachments to the SDK format, validating paths and filtering invalid entries. */


### PR DESCRIPTION
`isValidAttachmentPath()` used a hardcoded forward slash (`'/'`) when checking if an uploaded file path was inside the upload directory. On Windows, `node:path.resolve()` returns backslash-separated paths, so the `startsWith` check always failed - silently dropping every image attachment with an `ATTACHMENT_PATH_REJECTED` warning.

This was a bug we introduced in v1.0.0. Commit `bb9daa8` fixed the same class of Windows path separator issue in the frontend components but missed the server-side validation in `attachments.ts`. Apologies for the oversight.

**Fix:** Replace `'/'` with `node:path.sep` to support both platforms.

Also updated the test to use `join()` instead of a hardcoded `/` for the prefix-substring attack test case.